### PR TITLE
Promote packages

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -1,0 +1,97 @@
+env:
+  PANTS_CONFIG_FILES: "['pants.toml', 'pants.ci.toml']"
+  BUILDKITE_PLUGIN_VAULT_ENV_SECRET_PREFIX: "secret/data/buildkite/env"
+
+steps:
+
+  - label: ":lint-roller::bash: Lint Bash"
+    command:
+      - make lint-bash
+    # plugins:
+    #   - grapl-security/vault-login#v0.1.0
+    #   - grapl-security/vault-env#v0.1.0:
+    #       secrets:
+    #         - cloudsmith-login-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN
+
+  - label: ":lint-roller::docker: Lint Dockerfile"
+    command:
+      - make lint-docker
+
+  - label: ":lint-roller: Lint HCL"
+    command:
+      - make lint-hcl
+
+  - label: ":lint-roller::buildkite: Lint Plugin"
+    command:
+      - make lint-plugin
+
+  - label: ":bash: Unit Test Bash"
+    command:
+      - make test-bash
+    # plugins:
+    #   - grapl-security/vault-login#v0.1.0
+    #   - grapl-security/vault-env#v0.1.0:
+    #       secrets:
+    #         - vault-login-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN
+
+  - label: ":docker: Build Image"
+    command:
+      - make image
+
+  ########################################################################
+
+  - wait
+
+  - label: ":cloudsmith::docker: Upload testing container"
+    key: test-upload
+    command:
+      - docker buildx bake testing --push
+    plugins:
+      - grapl-security/vault-login#v0.1.0
+      - grapl-security/vault-env#v0.1.0:
+          secrets:
+            - CLOUDSMITH_API_KEY
+      - docker-login#v2.0.1:
+          username: grapl-cicd
+          password-env: CLOUDSMITH_API_KEY
+          server: docker.cloudsmith.io
+    agents:
+      queue: "docker"
+
+  - label: ":cloudsmith::buildkite: Promotion Test"
+    key: promotion-test
+    depends_on: test-upload
+    plugins:
+      - grapl-security/vault-login#v0.1.0
+      - grapl-security/vault-env#v0.1.0:
+          secrets:
+            - CLOUDSMITH_API_KEY
+      - grapl-security/cloudsmith#${BUILDKITE_COMMIT}:
+          # See contents of the
+          # `cloudsmith-buildkite-plugin-verify-test` target in
+          # `docker-bake.hcl` for where these values come from.
+          promote:
+            org: grapl
+            from: testing-stage1
+            to: testing-stage2
+            packages:
+              cloudsmith-buildkite-plugin-verify-test: ${BUILDKITE_BUILD_ID}
+    agents:
+      queue: "docker"  # could also be artifact-uploaders
+
+
+  - label: ":cloudsmith::white_check_mark: Verify Promotion"
+    key: verify-promotion
+    depends_on: promotion-test
+    command:
+      - .buildkite/scripts/verify_promotion.sh
+    plugins:
+      - grapl-security/vault-login#v0.1.0
+      - grapl-security/vault-env#v0.1.0:
+          secrets:
+            - CLOUDSMITH_API_KEY
+    agents:
+      queue: "docker"  # could also be artifact-uploaders
+
+   # TODO: Need to verify that this works with a file, too
+   # TODO: Need to verify that this works with multiple artifacts, too

--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -7,11 +7,11 @@ steps:
   - label: ":lint-roller::bash: Lint Bash"
     command:
       - make lint-bash
-    # plugins:
-    #   - grapl-security/vault-login#v0.1.0
-    #   - grapl-security/vault-env#v0.1.0:
-    #       secrets:
-    #         - cloudsmith-login-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN
+    plugins:
+      - grapl-security/vault-login#v0.1.0
+      - grapl-security/vault-env#v0.1.0:
+          secrets:
+            - cloudsmith-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN
 
   - label: ":lint-roller::docker: Lint Dockerfile"
     command:
@@ -28,11 +28,11 @@ steps:
   - label: ":bash: Unit Test Bash"
     command:
       - make test-bash
-    # plugins:
-    #   - grapl-security/vault-login#v0.1.0
-    #   - grapl-security/vault-env#v0.1.0:
-    #       secrets:
-    #         - vault-login-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN
+    plugins:
+      - grapl-security/vault-login#v0.1.0
+      - grapl-security/vault-env#v0.1.0:
+          secrets:
+            - cloudsmith-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN
 
   - label: ":docker: Build Image"
     command:
@@ -92,6 +92,3 @@ steps:
             - CLOUDSMITH_API_KEY
     agents:
       queue: "docker"  # could also be artifact-uploaders
-
-   # TODO: Need to verify that this works with a file, too
-   # TODO: Need to verify that this works with multiple artifacts, too

--- a/.buildkite/scripts/BUILD
+++ b/.buildkite/scripts/BUILD
@@ -1,0 +1,1 @@
+shell_library()

--- a/.buildkite/scripts/verify_promotion.sh
+++ b/.buildkite/scripts/verify_promotion.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# After uploading a container and then promoting it, we must verify
+# that the move actually happened as we expected.
+
+set -euo pipefail
+
+# Get access to our cloudsmith "binary"
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")/../../lib/cloudsmith.sh"
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")/../../lib/ops.sh"
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")/../../lib/log.sh"
+
+readonly image_name="cloudsmith-buildkite-plugin-verify-test"
+readonly image_tag="${BUILDKITE_BUILD_ID}"
+readonly fully_qualified_image_name="${image_name}:${image_tag}"
+
+query() {
+    local -r _repo="${1}"
+
+    # In this case, we don't care about the error message that
+    # `get_unique_identifier` can return.
+    get_unique_identifier grapl "${_repo}" "name:${image_name} version:${image_tag}" 2> /dev/null
+}
+
+echo "--- :cloudsmith: Verifying promotion out of source repository"
+if package_id=$(query testing-stage1); then
+    raise_error "Did not expect to find anything in testing-stage1, but found package with ID '${package_id}'!"
+else
+    echo "--- :cloudsmith: Did not find ${fully_qualified_image_name} in testing-stage1 repository, as expected"
+fi
+
+echo "--- :cloudsmith: Verifying promotion into destination repository"
+if package_id=$(query testing-stage2); then
+    echo "--- :cloudsmith: Found ${fully_qualified_image_name} in testing-stage2, with ID '${package_id}', as expected"
+else
+    raise_error "Expected to find ${fully_qualified_image_name} in testing-stage2, but did not!"
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.pants.d
+.pids

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -1,0 +1,9 @@
+FROM alpine:3.14
+
+ARG BUILDKITE_BUILD_ID
+ENV BUILDKITE_BUILD_ID="${BUILDKITE_BUILD_ID}"
+
+# Using shell form rather than exec form (i.e., `[...]`) so we get
+# expansion of the variable.
+# hadolint ignore=DL3025
+CMD echo "Built for testing in Buildkite run: ${BUILDKITE_BUILD_ID}"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,66 @@
+COMPOSE_USER=$(shell id -u):$(shell id -g)
+
+RUN_CHECK := docker-compose run --rm --user=${COMPOSE_USER}
+
+.DEFAULT_GOAL=all
+
+# Formatting
+########################################################################
+
+.PHONY: format
+format: format-hcl format-bash
+
+.PHONY: format-hcl
+format-hcl:
+	${RUN_CHECK} hcl-formatter
+
+.PHONY: format-bash
+format-bash:
+	./pants fmt ::
+
+# Linting
+########################################################################
+
+.PHONY: lint
+lint: lint-docker lint-hcl lint-bash lint-plugin
+
+.PHONY: lint-docker
+lint-docker:
+	${RUN_CHECK} hadolint
+
+.PHONY: lint-hcl
+lint-hcl:
+	${RUN_CHECK} hcl-linter
+
+.PHONY: lint-bash
+lint-bash:
+	./pants lint ::
+
+.PHONY: lint-plugin
+lint-plugin:
+	${RUN_CHECK} plugin-linter
+
+# Testing
+########################################################################
+.PHONY: test
+test: test-bash
+
+.PHONY: test-bash
+test-bash:
+	./pants test ::
+
+# Containers
+########################################################################
+
+.PHONY: image
+image:
+	docker buildx bake
+
+.PHONY: image-push
+image-push:
+	docker buildx bake --push
+
+########################################################################
+
+.PHONY: all
+all: format lint test image

--- a/README.md
+++ b/README.md
@@ -1,0 +1,136 @@
+# Cloudsmith Buildkite Plugin
+
+Interact with [Cloudsmith](https://cloudsmith.io) package
+repositories.
+
+Currently only provides the ability to promote (move) packages from
+one repository to another.
+
+Expects a `CLOUDSMITH_API_KEY` to be present in the environment.
+
+## Promote Packages
+
+Move one or more packages from one repository to another.
+
+This takes place in a `command` hook, and is thus expected to run in its own Buildkite job.
+
+As detailed in [the Cloudsmith
+documentation](https://help.cloudsmith.io/docs/move-a-package),
+promotion requires a unique identifier for the package you want to
+move. This ends up looking something like `iwrWp7mk8kAP`. Rather than
+requiring users to provide that to the plugin, you can specify your
+package in terms of name and version. These are then fed into a
+`cloudsmith list packages` query to resolve the unique identifier
+required for the promotion.
+
+```yaml
+steps:
+  - label: ":cloudsmith: Promote Packages for Release"
+    plugins:
+      - grapl-security/cloudsmith#v0.1.0:
+          promote:
+            org: my-company
+            from: testing
+            to: releases
+            packages:
+              frontend: v1.2.3
+              backend: v2.3.4
+```
+
+As an alternative to specifying packages explicitly, you can pass in a
+file containing the packages. This can be useful for more dynamic
+workflows.
+
+```yaml
+steps:
+  - label: ":cloudsmith: Promote Packages for Release"
+    plugins:
+      - grapl-security/cloudsmith#v0.1.0:
+          promote:
+            org: my-company
+            from: testing
+            to: releases
+            packages_file: validated_packages.json
+```
+
+Here, `validated_packages.json` has the following contents:
+
+```json
+{
+    "frontend": "v1.2.3",
+    "backend": "v2.3.4"
+}
+```
+
+The structure of this file is the same as that of the `packages` key,
+just expressed as JSON.
+
+This configuration has the same effect as the one above that used
+`packages` instead of `packages_file`, but provides more flexibility
+for how the packages are specified.
+
+You must specify either `packages` or `packages_file`; you cannot have
+both, but you must have one.
+
+## Docker Image
+
+For flexibility, this plugin uses a containerized Cloudsmith CLI,
+meaning that you can use this plugin directly, without having to
+install the CLI on your Buildkite agents.
+
+Since there is not currently an official Cloudsmith CLI container
+image, we [build one ourselves](./Dockerfile) and make it available
+for this plugin. The image can be overridden, however, if you wish to
+use a different one; see the `Configuration` section below.
+
+## Configuration
+
+### image (optional, string)
+
+The container image with the Cloudsmith CLI binary that the plugin
+uses. Any container used should have the `cloudsmith` binary as its
+entrypoint.
+
+Defaults to `docker.cloudsmith.io/grapl/releases/cloudsmith-cli`.
+
+### tag (optional, string)
+
+The container image tag the plugin uses.
+
+Defaults to `latest`.
+
+### promote (required, object)
+
+The configuration object for the promotion operation.
+
+#### org (required, string)
+
+The Cloudsmith organization to interact with.
+
+#### from (required, string)
+
+The repository you are promoting packages out of.
+
+#### to (required, string)
+
+The repository you are promoting packages into.
+
+#### packages (optional, object)
+
+A flat object mapping package names to package versions. These are the
+packages that will be promoted.
+
+Cannot be used if `packages_file` is used.
+
+#### packages_file (optional, string)
+
+The path to a file containing a JSON object with the same mapping
+described in `packages` above.
+
+Cannot be used if `packages` is used.
+
+## Building
+
+Requires `make`, `docker`, and `docker-compose`.
+
+Running `make` will run all formatting, linting, and testing.

--- a/README.md
+++ b/README.md
@@ -134,3 +134,11 @@ Cannot be used if `packages` is used.
 Requires `make`, `docker`, and `docker-compose`.
 
 Running `make` will run all formatting, linting, and testing.
+
+### Testing Considerations
+
+Part of exercising this plugin involves pushing a test container to
+one repository (`testing-stage1`) and promoting it to another
+(`testing-stage2`). These two repositories exist in our Cloudsmith
+account solely for this purpose, and this repository is the only thing
+that will be putting anything into them.

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -17,3 +17,27 @@ target "cloudsmith-cli" {
     "docker.cloudsmith.io/grapl/raw/cloudsmith-cli:${CLOUDSMITH_CLI_VERSION}"
   ]
 }
+
+########################################################################
+
+group "testing" {
+  targets = ["cloudsmith-buildkite-plugin-verify-test"]
+}
+
+variable "BUILDKITE_BUILD_ID" {
+  default = "not-running-in-buildkite"
+}
+
+# If you change any values in here, make sure to make the
+# corresponding changes, if any, to .buildkite/plugin.verify.yml and
+# .buildkite/scripts/verify_promotion.sh
+target "cloudsmith-buildkite-plugin-verify-test" {
+  context    = "."
+  dockerfile = "Dockerfile.testing"
+  args = {
+    "BUILDKITE_BUILD_ID" = "${BUILDKITE_BUILD_ID}"
+  }
+  tags = [
+    "docker.cloudsmith.io/grapl/testing-stage1/cloudsmith-buildkite-plugin-verify-test:${BUILDKITE_BUILD_ID}"
+  ]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+version: "3.8"
+
+x-common-variables:
+  read-only-workdir: &read-only-workdir
+    type: bind
+    source: .
+    target: /workdir
+    read_only: true
+  read-write-workdir: &read-write-workdir
+    type: bind
+    source: .
+    target: /workdir
+    read_only: false
+  read-only-plugin: &read-only-plugin
+    # Buildkite containers assume you mount into /plugin
+    type: bind
+    source: .
+    target: /plugin
+    read_only: true
+
+services:
+  hcl-formatter:
+    image: docker.cloudsmith.io/grapl/releases/hcl-formatter:latest
+    command: format
+    volumes:
+      - *read-write-workdir
+
+  hcl-linter:
+    image: docker.cloudsmith.io/grapl/releases/hcl-formatter:latest
+    command: lint
+    volumes:
+      - *read-only-workdir
+
+  hadolint:
+    image: hadolint/hadolint:2.6.0-debian
+    command: [ "hadolint", "Dockerfile", "Dockerfile.testing" ]
+    working_dir: /workdir
+    volumes:
+      - *read-only-workdir
+
+  plugin-linter:
+    image: buildkite/plugin-linter:latest # the only available tag
+    command: ["--id", "grapl-security/cloudsmith"]
+    volumes:
+      - *read-only-plugin

--- a/hooks/BUILD
+++ b/hooks/BUILD
@@ -1,0 +1,3 @@
+shell_library(
+    sources=["command"]
+)

--- a/hooks/command
+++ b/hooks/command
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/cloudsmith.sh"
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/configuration.sh"
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/ops.sh"
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/log.sh"
+
+# Because of the current structure of the configuration object, it's
+# easier to deal with pulling the configuration values from JSON,
+# rather than environment variables, as is normally seen in Buildkite plugins.
+
+configuration=$(plugin_configuration)
+packages=$(get_packages "${configuration}")
+
+cloudsmith_org=$(get_org "${configuration}")
+from_repo=$(get_from "${configuration}")
+to_repo=$(get_to "${configuration}")
+
+queries=("$(packages_to_queries "${packages}")")
+
+echo "--- :cloudsmith: Promoting packages from ${cloudsmith_org}/${from_repo} to ${cloudsmith_org}/${to_repo}"
+
+for query in "${queries[@]}"; do
+    echo "--- :cloudsmith: Processing query '${query}'"
+    slug="$(get_unique_identifier "${cloudsmith_org}" "${from_repo}" "${query}")"
+    promote "${cloudsmith_org}" "${from_repo}" "${to_repo}" "${slug}"
+done

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -1,0 +1,7 @@
+shell_library()
+
+shunit2_tests(
+    name="tests",
+    # Currently using relative imports for tests, which aren't visible to Pants
+    dependencies=[":lib"]
+)

--- a/lib/cloudsmith.sh
+++ b/lib/cloudsmith.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly default_image="docker.cloudsmith.io/grapl/releases/cloudsmith-cli"
+readonly default_tag="latest"
+# TODO: add a "debug" mode where we spit out the specific image and
+# commands being used
+readonly image="${BUILDKITE_PLUGIN_CLOUDSMITH_IMAGE:-${default_image}}:${BUILDKITE_PLUGIN_CLOUDSMITH_TAG:-${default_tag}}"
+
+# Wrap up the invocation of a Cloudsmith container image to alleviate the
+# need to have a Cloudsmith binary installed on the Buildkite agent machine
+# already. Scripts can just source this file and then call `cloudsmith`
+# like normal.
+# TODO: If used to upload raw files, we would also need to mount the current directory.
+cloudsmith() {
+    docker run \
+        --init \
+        --rm \
+        --env=CLOUDSMITH_API_KEY \
+        -- \
+        "${image}" "$@"
+}

--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")/log.sh"
+
+# Return this plugin's configuration as a JSON string.
+#
+# Assumes that there is only a single instance of this plugin
+# configured for the current job (which is a valid assumption at this
+# point).
+plugin_configuration() {
+    jq --raw-output --exit-status '.
+       | map(to_entries
+       |     .[]
+       |     select(.key | test("grapl-security/cloudsmith")))
+       | .[0].value' <<< "${BUILDKITE_PLUGINS}" ||
+        raise_error "Could not parse JSON plugin configuration for grapl-security/cloudsmith plugin from environment:\n$(jq '.' <<< "${BUILDKITE_PLUGINS}")"
+}
+
+# Retrieve the packages manifest object from a configured file or
+# from explicitly-registered packages in the plugin configuration.
+get_packages() {
+    local -r _config="${1}"
+
+    if the_file=$(jq --raw-output --exit-status '.promote.packages_file' <<< "${_config}"); then
+        # we were given a file; read the packages from it
+        if [ -e "${the_file}" ]; then
+            jq --raw-output --exit-status '.' "${the_file}" ||
+                raise_error "promote.packages_file '${the_file}' does not appear to contain valid JSON:\n$(cat "${the_file}")"
+        else
+            raise_error "promote.packages_file '${the_file}' does not appear to exist; did you forget to add it?"
+        fi
+    else
+        # read the packages object from the configuration
+        jq --raw-output --exit-status '.promote.packages' <<< "${_config}" ||
+            raise_error "promote.packages could not found"
+    fi
+}
+
+get_org() {
+    _get_configuration_value ".promote.org" "${1}"
+}
+
+get_from() {
+    _get_configuration_value ".promote.from" "${1}"
+}
+
+get_to() {
+    _get_configuration_value ".promote.to" "${1}"
+}
+
+_get_configuration_value() {
+    local -r _key_path="${1}"
+    local -r _config="${2}"
+
+    if ! value=$(jq --raw-output --exit-status "${_key_path}" <<< "${_config}"); then
+        raise_error "Expected value at '${_key_path}'\n$(jq '.' <<< "${_config}")"
+    fi
+    echo "${value}"
+}

--- a/lib/configuration_test.sh
+++ b/lib/configuration_test.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+
+plugin_configuration_with_explicit_packages() {
+    cat << EOF
+[
+  {"grapl-security/vault-login#v0.1.0": {}},
+  {"grapl-security/vault-env#v0.1.0": {}},
+  {
+    "grapl-security/cloudsmith-buildkite-plugin#deadbeef": {
+      "promote": {
+        "to": "releases",
+        "org": "grapl",
+        "from": "raw",
+        "packages": {
+          "foo": "1.2.3",
+          "bar": "2.3.4"
+        }
+      }
+    }
+  },
+  {"superawesomesauce/something-nifty-that-definitely-exists-yup#1.0.0": {}}
+]
+EOF
+}
+
+plugin_configuration_with_packages_file() {
+    cat << EOF
+[
+  {"grapl-security/vault-login#v0.1.0": {}},
+  {"grapl-security/vault-env#v0.1.0": {}},
+  {
+    "grapl-security/cloudsmith-buildkite-plugin#deadbeef": {
+      "promote": {
+        "to": "releases",
+        "org": "grapl",
+        "from": "raw",
+        "packages_file": "${SHUNIT_TMPDIR}/packages.json"
+      }
+    }
+  },
+  {"superawesomesauce/something-nifty-that-definitely-exists-yup#1.0.0": {}}
+]
+EOF
+}
+
+oneTimeSetUp() {
+    # shellcheck source-path=SCRIPTDIR
+    source "$(dirname "${BASH_SOURCE[0]}")/configuration.sh"
+}
+
+setUp() {
+    unset BUILDKITE_PLUGINS
+}
+
+tearDown() {
+    unset BUILDKITE_PLUGINS
+}
+
+test_plugin_configuration_returns_proper_result() {
+
+    BUILDKITE_PLUGINS=$(plugin_configuration_with_explicit_packages)
+
+    expected=$(
+        cat << EOF
+{
+  "promote": {
+    "to": "releases",
+    "org": "grapl",
+    "from": "raw",
+    "packages": {
+      "foo": "1.2.3",
+      "bar": "2.3.4"
+    }
+  }
+}
+EOF
+    )
+
+    output="$(plugin_configuration)"
+    assertEquals "Did not retrieve the expected configuration!" \
+        "$(jq -r '.' <<< "${expected}")" \
+        "$(jq -r '.' <<< "${output}")"
+}
+
+test_get_packages_from_explicit_configuration() {
+    BUILDKITE_PLUGINS=$(plugin_configuration_with_explicit_packages)
+    expected=$(
+        cat << EOF
+{
+    "foo": "1.2.3",
+    "bar": "2.3.4"
+}
+EOF
+    )
+
+    configuration=$(plugin_configuration)
+    output="$(get_packages "${configuration}")"
+
+    assertEquals "Did not retrieve the expected packages!" \
+        "$(jq -r '.' <<< "${expected}")" \
+        "$(jq -r '.' <<< "${output}")"
+}
+
+test_get_packages_from_file() {
+    expected=$(
+        cat << EOF
+{
+    "my_package": "1.1.1",
+    "your_package": "2.2.2",
+    "someone_elses_package": "3.3.3"
+}
+EOF
+    )
+
+    echo "${expected}" > "${SHUNIT_TMPDIR}/packages.json"
+
+    BUILDKITE_PLUGINS="$(plugin_configuration_with_packages_file)"
+
+    configuration=$(plugin_configuration)
+    output="$(get_packages "${configuration}")"
+
+    assertEquals "Did not retrieve the expected packages!" \
+        "$(jq -r '.' <<< "${expected}")" \
+        "$(jq -r '.' <<< "${output}")"
+
+}
+
+test_get_org_works() {
+    actual="$(get_org '{"promote": {"org": "my-org"}}')"
+    expected="my-org"
+    assertEquals "${expected}" "${actual}"
+}
+
+test_get_org_fails_with_missing_value() {
+    actual="$(get_org '{"promote": {"stuff": "blah"}}' 2>&1)"
+    assertEquals "'get_org' should have failed" 1 $?
+    expected_error_message="Expected value at '.promote.org'"
+    assertContains "Did not find expected message in '${actual}'" "${actual}" "${expected_error_message}"
+}
+
+test_get_from_works() {
+    actual="$(get_from '{"promote": {"org": "my-org", "from": "source-repo"}}')"
+    expected="source-repo"
+    assertEquals "${expected}" "${actual}"
+}
+
+test_get_from_fails_with_missing_value() {
+    actual="$(get_from '{"promote": {"org": "my-org"}}' 2>&1)"
+    assertEquals "'get_from' should have failed" 1 $?
+    expected_error_message="Expected value at '.promote.from'"
+    assertContains "Did not find expected message in '${actual}'" "${actual}" "${expected_error_message}"
+}
+
+test_get_to_works() {
+    actual="$(get_to '{"promote": {"org": "my-org", "from": "source-repo", "to": "dest-repo"}}')"
+    expected="dest-repo"
+    assertEquals "${expected}" "${actual}"
+}
+
+test_get_to_fails_with_missing_value() {
+    actual="$(get_to '{"promote": {"org": "my-org", "from": "source-repo"}}' 2>&1)"
+    assertEquals "'get_to' should have failed" 1 $?
+    expected_error_message="Expected value at '.promote.to'"
+    assertContains "Did not find expected message in '${actual}'" "${actual}" "${expected_error_message}"
+}

--- a/lib/log.sh
+++ b/lib/log.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+log() {
+    echo -e "${@}" >&2
+}
+
+raise_error() {
+    log "--- :rotating_light:" "${@}"
+    # Yes, these numbers are correct :/
+    log "Failed in ${FUNCNAME[1]}() at [${BASH_SOURCE[1]}:${BASH_LINENO[0]}], called from [${BASH_SOURCE[2]}:${BASH_LINENO[1]}]"
+    exit 1
+}

--- a/lib/ops.sh
+++ b/lib/ops.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")/log.sh"
+
+# Generate a series of Cloudsmith query strings to use in `cloudsmith
+# package list` call
+packages_to_queries() {
+    local -r _packages="${1}"
+
+    jq --raw-output --exit-status '
+        to_entries
+        | .[]
+        | "name:" + .key + " " + "version:" + .value' \
+        <<< "${_packages}" ||
+        raise_error "Problem converting package specifications to Cloudsmith query strings:\n${_packages}"
+}
+
+# Retrieve the unique identifier of a given package; this is needed
+# for promotion.
+#
+# Accepts a query string that is implicitly assumed to refer to a
+# single package instance.
+#
+# See https://help.cloudsmith.io/docs/identifying-a-package for
+# further details.
+get_unique_identifier() {
+    local -r _org="${1}"
+    local -r _from_repo="${2}"
+    local -r _query="${3}"
+
+    # Unfortunately, we can't use --debug and --verbose here due to
+    # mingling of stdout and stderr in the CLI itself; it pollutes the
+    # JSON we're trying to capture :(
+    if ! result=$(cloudsmith list packages \
+        "${_org}/${_from_repo}" \
+        --query="${_query}" \
+        --output-format=json); then
+        raise_error "Cloudsmith list packages failed!\n${result}"
+    fi
+
+    if ! jq --exit-status '.' <<< "${result}" &> /dev/null; then
+        raise_error "Could not parse 'cloudsmith list packages' output as JSON:\n${result}"
+    fi
+
+    if len=$(jq --raw-output --exit-status '(.data // empty) | length' <<< "${result}"); then
+        if [ 1 == "${len}" ]; then
+            jq --raw-output --exit-status '.data[0].slug_perm' <<< "${result}" ||
+                raise_error "Unexpected missing 'slug_perm' key of search result:\n$(jq '.data[0]' <<< "${result}")"
+        else
+            raise_error "Expected query '${_query}' to return a single package, but it returned ${len}"
+        fi
+    else
+        raise_error "Unexpected missing 'data' key to 'cloudsmith list packages' output:\n$(jq '.' <<< "${result}")"
+    fi
+}
+
+# Promote a package from one repository to another
+promote() {
+    local -r _org="${1}"
+    local -r _from_repo="${2}"
+    local -r _to_repo="${3}"
+    local -r _slug="${4}"
+
+    cloudsmith promote \
+        --yes \
+        "${_org}/${_from_repo}/${_slug}" \
+        "${_to_repo}"
+}

--- a/lib/ops_test.sh
+++ b/lib/ops_test.sh
@@ -1,0 +1,307 @@
+#!/usr/bin/env bash
+
+# mock `cloudsmith` binary
+#
+# This prevents the actual `cloudsmith` binary from being executed during
+# these tests. Every invocation is logged to a file.
+#
+# To make assertions, simply inspect the contents of the file to
+# ensure that the expected commands _would_ have been invoked.
+
+cloudsmith() {
+    echo "${FUNCNAME[0]} $*" >> "${ALL_COMMANDS}"
+
+    case "$*" in
+        list\ packages\ schmapl/no-packages*)
+            cat << EOF
+{
+  "data": []
+}
+EOF
+            ;;
+
+        list\ packages\ schmapl/too-many-packages*)
+            # The contents aren't important; just the fact that there
+            # are more than one item in `data`
+            cat << EOF
+{
+  "data": [{},{},{}]
+}
+EOF
+            ;;
+
+        list\ packages\ schmapl/missing-slug*)
+            cat << EOF
+{
+  "data": [{"slug": "really-wanted slug_perm as the key"}]
+}
+EOF
+            ;;
+
+        list\ packages\ schmapl/not-json*)
+            cat <<< "This is not JSON... did you forget to add --output-format=json?"
+            ;;
+
+        list\ packages\ schmapl/wrong-structure*)
+            cat << EOF
+{
+    "stuff": []
+}
+EOF
+            ;;
+
+        list\ packages\ schmapl/failure*)
+            echo "Haha, this failed"
+            exit 1
+            ;;
+
+        list\ packages\ schmapl/bucket-o-stuff*)
+            cat << EOF
+{
+  "data": [
+    {
+      "architectures": [
+        {
+          "description": null,
+          "name": "amd64"
+        }
+      ],
+      "cdn_url": null,
+      "checksum_md5": "",
+      "checksum_sha1": "",
+      "checksum_sha256": "",
+      "checksum_sha512": "",
+      "dependencies_checksum_md5": null,
+      "description": null,
+      "distro": null,
+      "distro_version": null,
+      "downloads": 6,
+      "epoch": null,
+      "extension": "",
+      "filename": "my-amazing-service",
+      "files": [],
+      "format": "docker",
+      "format_url": "https://api.cloudsmith.io/v1/formats/docker/",
+      "identifier_perm": "8QzX5yKpxFLz",
+      "indexed": true,
+      "is_sync_awaiting": false,
+      "is_sync_completed": true,
+      "is_sync_failed": false,
+      "is_sync_in_flight": false,
+      "is_sync_in_progress": false,
+      "license": null,
+      "name": "my-amazing-service",
+      "namespace": "schmapl",
+      "namespace_url": "https://api.cloudsmith.io/v1/namespaces/schmapl/",
+      "num_files": 0,
+      "package_type": "1",
+      "release": null,
+      "repository": "bucket-o-stuff",
+      "repository_url": "https://api.cloudsmith.io/v1/repos/schmapl/bucket-o-stuff/",
+      "security_scan_completed_at": "2021-11-10T17:06:35.233244Z",
+      "security_scan_started_at": null,
+      "security_scan_status": "Security Scanning Failed",
+      "security_scan_status_updated_at": "2021-11-10T17:06:35.233234Z",
+      "self_html_url": "https://cloudsmith.io/~schmapl/repos/bucket-o-stuff/packages/detail/docker/my-amazing-service/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/a=amd64;xpo=linux/",
+      "self_url": "https://api.cloudsmith.io/v1/packages/schmapl/bucket-o-stuff/8QzX5yKpxFLz/",
+      "signature_url": null,
+      "size": 52302313,
+      "slug": "my-amazing-service-ZZZ",
+      "slug_perm": "8QzX5yKpxFLz",
+      "stage": "9",
+      "stage_str": "Fully Synchronised",
+      "stage_updated_at": "2021-11-10T17:05:15.228098Z",
+      "status": "4",
+      "status_reason": null,
+      "status_str": "Completed",
+      "status_updated_at": "2021-11-10T17:05:15.224372Z",
+      "status_url": "https://api.cloudsmith.io/v1/packages/schmapl/bucket-o-stuff/8QzX5yKpxFLz/status/",
+      "subtype": null,
+      "summary": null,
+      "sync_finished_at": "2021-11-10T17:05:15.228092Z",
+      "sync_progress": 100,
+      "tags": {
+        "version": [
+          "1.2.3"
+        ]
+      },
+      "tags_immutable": {},
+      "type_display": "image",
+      "uploaded_at": "2021-11-10T17:05:04.563209Z",
+      "uploader": "uploadey-the-amazing-uploader",
+      "uploader_url": "https://api.cloudsmith.io/v1/users/profile/uploadey-the-amazing-uploader/",
+      "version": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "version_orig": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "vulnerability_scan_results_url": "https://api.cloudsmith.io/v1/vulnerabilities/schmapl/bucket-o-stuff/8QzX5yKpxFLz/"
+    }
+  ],
+  "meta": {
+    "pagination": {
+      "page": 1,
+      "page_max": 1,
+      "page_results_from": 1,
+      "page_results_len": 0,
+      "page_results_to": 1,
+      "page_size": 30,
+      "results_total": 1
+    }
+  }
+}
+EOF
+            ;;
+        *) ;;
+    esac
+}
+
+recorded_commands() {
+    if [ -f "${ALL_COMMANDS}" ]; then
+        cat "${ALL_COMMANDS}"
+    fi
+}
+
+oneTimeSetUp() {
+    # shellcheck source-path=SCRIPTDIR
+    source "$(dirname "${BASH_SOURCE[0]}")/ops.sh"
+    export ALL_COMMANDS="${SHUNIT_TMPDIR}/all_commands"
+}
+
+setUp() {
+    # Ensure any recorded commands from the last test are removed so
+    # we start with a clean slate.
+    rm -f "${ALL_COMMANDS}"
+}
+
+test_packages_to_queries_generates_the_expected_queries() {
+    packages=$(
+        cat << EOF
+{
+    "foo": "1.2.3",
+    "bar": "2.3.4"
+}
+EOF
+    )
+
+    expected=$(
+        cat << EOF
+name:foo version:1.2.3
+name:bar version:2.3.4
+EOF
+    )
+    output="$(packages_to_queries "${packages}")"
+    assertEquals "${expected}" "${output}"
+}
+
+test_slug() {
+    expected_commands=$(
+        cat << EOF
+cloudsmith list packages schmapl/bucket-o-stuff --query="name:my-amazing-service version:1.2.3" --output-format=json
+EOF
+    )
+
+    actual=$(get_unique_identifier schmapl bucket-o-stuff '"name:my-amazing-service version:1.2.3"')
+    expected=8QzX5yKpxFLz
+
+    assertEquals "The expected cloudsmith commands were not run" \
+        "${expected_commands}" \
+        "$(recorded_commands)"
+    assertEquals "The expected slug was not extracted" \
+        "${expected}" \
+        "${actual}"
+}
+
+test_promote() {
+
+    expected_commands=$(
+        cat << EOF
+cloudsmith promote --yes schmapl/bucket-o-stuff/8QzX5yKpxFLz validated-bucket-o-stuff
+EOF
+    )
+
+    promote schmapl bucket-o-stuff validated-bucket-o-stuff 8QzX5yKpxFLz
+
+    assertEquals "The expected cloudsmith commands were not run" \
+        "${expected_commands}" \
+        "$(recorded_commands)"
+}
+
+test_packages_to_queries_works_with_valid_json() {
+
+    expected=$(
+        cat << EOF
+name:foo version:1.2.3
+name:barf version:4.5.6
+EOF
+    )
+    actual="$(packages_to_queries '{"foo": "1.2.3", "barf": "4.5.6"}')"
+
+    assertEquals "${expected}" "${actual}"
+}
+
+test_packages_to_queries_fails_with_wrong_json() {
+    # Capture stderr to get access to the error message so we can make
+    # assertions about it.
+    actual="$(packages_to_queries '["foo", "1.2.3", "barf", "4.5.6"]' 2>&1)"
+
+    # That invocation should have failed (exit code 1)
+    assertEquals "'packages_to_queries' should have failed" 1 $?
+
+    expected_error_message="Problem converting package specifications to Cloudsmith query strings"
+    assertContains "Did not find expected message in '${actual}'" "${actual}" "${expected_error_message}"
+}
+
+test_get_unique_identifier_fails_if_query_identifies_no_packages() {
+
+    actual="$(get_unique_identifier schmapl no-packages 'name:blah version:1.0.0' 2>&1)"
+
+    assertEquals "'get_unique_identifier' should have failed" 1 $?
+
+    expected_error_message="Expected query 'name:blah version:1.0.0' to return a single package, but it returned 0"
+    assertContains "Did not find expected message in '${actual}'" "${actual}" "${expected_error_message}"
+}
+
+test_get_unique_identifier_fails_if_query_identifies_multiple_packages() {
+
+    actual="$(get_unique_identifier schmapl too-many-packages 'name:foobar version:2.0.0' 2>&1)"
+
+    assertEquals "'get_unique_identifier' should have failed" 1 $?
+
+    expected_error_message="Expected query 'name:foobar version:2.0.0' to return a single package, but it returned 3"
+    assertContains "Did not find expected message in '${actual}'" "${actual}" "${expected_error_message}"
+}
+
+test_get_unique_identifier_fails_if_slug_perm_key_is_not_found() {
+
+    actual="$(get_unique_identifier schmapl missing-slug 'name:foo version:3.0.0' 2>&1)"
+
+    assertEquals "'get_unique_identifier' should have failed" 1 $?
+
+    expected_error_message="Unexpected missing 'slug_perm' key of search result"
+    assertContains "Did not find expected message in '${actual}'" "${actual}" "${expected_error_message}"
+}
+
+test_get_unique_identifier_fails_if_query_does_not_return_json() {
+    actual="$(get_unique_identifier schmapl not-json 'name:bad version:4.0.0' 2>&1)"
+
+    assertEquals "'get_unique_identifier' should have failed" 1 $?
+
+    expected_error_message="Could not parse 'cloudsmith list packages' output as JSON"
+    assertContains "Did not find expected message in '${actual}'" "${actual}" "${expected_error_message}"
+}
+
+test_get_unique_identifier_fails_if_json_is_not_correct_structure() {
+    actual="$(get_unique_identifier schmapl wrong-structure 'name:super-bad version:5.0.0' 2>&1)"
+
+    assertEquals "'get_unique_identifier' should have failed" 1 $?
+
+    expected_error_message="Unexpected missing 'data' key to 'cloudsmith list packages' output"
+    assertContains "Did not find expected message in '${actual}'" "${actual}" "${expected_error_message}"
+}
+
+test_get_unique_identifier_fails_if_json_is_not_correct_structure() {
+    actual="$(get_unique_identifier schmapl failure 'name:objectively-horrible version:6.0.0' 2>&1)"
+
+    assertEquals "'get_unique_identifier' should have failed" 1 $?
+
+    expected_error_message="Cloudsmith list packages failed!"
+    assertContains "Did not find expected message in '${actual}'" "${actual}" "${expected_error_message}"
+}

--- a/pants
+++ b/pants
@@ -1,0 +1,345 @@
+#!/usr/bin/env bash
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# =============================== NOTE ===============================
+# This ./pants bootstrap script comes from the pantsbuild/setup
+# project. It is intended to be checked into your code repository so
+# that other developers have the same setup.
+#
+# Learn more here: https://www.pantsbuild.org/docs/installation
+# ====================================================================
+
+set -eou pipefail
+
+# NOTE: To use an unreleased version of Pants from the pantsbuild/pants master branch,
+#  locate the master branch SHA, set PANTS_SHA=<SHA> in the environment, and run this script as usual.
+#
+# E.g., PANTS_SHA=725fdaf504237190f6787dda3d72c39010a4c574 ./pants --version
+
+PYTHON_BIN_NAME="${PYTHON:-unspecified}"
+
+# Set this to specify a non-standard location for this script to read the Pants version from.
+# NB: This will *not* cause Pants itself to use this location as a config file.
+#     You can use PANTS_CONFIG_FILES or --pants-config-files to do so.
+PANTS_TOML=${PANTS_TOML:-pants.toml}
+
+PANTS_BIN_NAME="${PANTS_BIN_NAME:-$0}"
+
+PANTS_SETUP_CACHE="${PANTS_SETUP_CACHE:-${XDG_CACHE_HOME:-$HOME/.cache}/pants/setup}"
+# If given a relative path, we fix it to be absolute.
+if [[ "$PANTS_SETUP_CACHE" != /* ]]; then
+  PANTS_SETUP_CACHE="${PWD}/${PANTS_SETUP_CACHE}"
+fi
+
+PANTS_BOOTSTRAP="${PANTS_SETUP_CACHE}/bootstrap-$(uname -s)-$(uname -m)"
+
+PEX_VERSION=2.1.42
+PEX_URL="https://github.com/pantsbuild/pex/releases/download/v${PEX_VERSION}/pex"
+PEX_EXPECTED_SHA256="69d6b1b1009b00dd14a3a9f19b72cff818a713ca44b3186c9b12074b2a31e51f"
+
+VIRTUALENV_VERSION=20.4.7
+VIRTUALENV_REQUIREMENTS=$(
+cat << EOF
+virtualenv==${VIRTUALENV_VERSION} --hash sha256:2b0126166ea7c9c3661f5b8e06773d28f83322de7a3ff7d06f0aed18c9de6a76
+filelock==3.0.12 --hash sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836
+six==1.16.0 --hash sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
+distlib==0.3.2 --hash sha256:23e223426b28491b1ced97dc3bbe183027419dfc7982b4fa2f05d5f3ff10711c
+appdirs==1.4.4 --hash sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128
+importlib-resources==5.1.4; python_version < "3.7" --hash sha256:e962bff7440364183203d179d7ae9ad90cb1f2b74dcb84300e88ecc42dca3351
+importlib-metadata==4.5.0; python_version < "3.8" --hash sha256:833b26fb89d5de469b24a390e9df088d4e52e4ba33b01dc5e0e4f41b81a16c00
+zipp==3.4.1; python_version < "3.10" --hash sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098
+typing-extensions==3.10.0.0; python_version < "3.8" --hash sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84
+EOF
+)
+
+COLOR_RED="\x1b[31m"
+COLOR_GREEN="\x1b[32m"
+COLOR_RESET="\x1b[0m"
+
+function log() {
+  echo -e "$@" 1>&2
+}
+
+function die() {
+  (($# > 0)) && log "${COLOR_RED}$*${COLOR_RESET}"
+  exit 1
+}
+
+function green() {
+  (($# > 0)) && log "${COLOR_GREEN}$*${COLOR_RESET}"
+}
+
+function tempdir {
+  mkdir -p "$1"
+  mktemp -d "$1"/pants.XXXXXX
+}
+
+function get_exe_path_or_die {
+  local exe="$1"
+  if ! command -v "${exe}"; then
+    die "Could not find ${exe}. Please ensure ${exe} is on your PATH."
+  fi
+}
+
+function get_pants_config_value {
+  local config_key="$1"
+  local optional_space="[[:space:]]*"
+  local prefix="^${config_key}${optional_space}=${optional_space}"
+  local raw_value
+  raw_value="$(sed -ne "/${prefix}/ s#${prefix}##p" "${PANTS_TOML}")"
+  echo "${raw_value}"  | tr -d \"\' && return 0
+  return 0
+}
+
+function get_python_major_minor_version {
+  local python_exe="$1"
+  "$python_exe" <<EOF
+import sys
+major_minor_version = ''.join(str(version_num) for version_num in sys.version_info[0:2])
+print(major_minor_version)
+EOF
+}
+
+# The high-level flow:
+#
+# 1.) Resolve the Pants version from config so that we know what interpreters we can use, what to name the venv,
+#     and what to install via pip.
+# 2.) Resolve the Python interpreter, first reading from the env var $PYTHON, then using a default based on the Pants
+#     version.
+# 3.) Check if the venv already exists via a naming convention, and create the venv if not found.
+# 4.) Execute Pants with the resolved Python interpreter and venv.
+#
+# After that, Pants itself will handle making sure any requested plugins
+# are installed and up to date.
+
+function determine_pants_version {
+  if [ -n "${PANTS_SHA:-}" ]; then
+    # get_version_for_sha will echo the version, thus "returning" it from this function.
+    get_version_for_sha "$PANTS_SHA"
+    return
+  fi
+
+  pants_version="$(get_pants_config_value 'pants_version')"
+  if [[ -z "${pants_version}" ]]; then
+    die "Please explicitly specify the \`pants_version\` in your \`pants.toml\` under the \`[GLOBAL]\` scope.
+See https://pypi.org/project/pantsbuild.pants/#history for all released versions
+and https://www.pantsbuild.org/docs/installation for more instructions."
+  fi
+  pants_major_version="$(echo "${pants_version}" | cut -d '.' -f1)"
+  pants_minor_version="$(echo "${pants_version}" | cut -d '.' -f2)"
+  # 1.26 is the first version to support `pants.toml`, so we fail eagerly if using an outdated version.
+  if [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -le 25 ]]; then
+    die "This version of the \`./pants\` script does not work with Pants <= 1.25.0 (and it also requires using \`pants.toml\`,
+rather than \`pants.ini\`). Instead, either upgrade your \`pants_version\` or use the version of the \`./pants\` script
+at https://raw.githubusercontent.com/Eric-Arellano/setup/0d445edef57cb89fd830db70810e38f050b0a268/pants."
+  fi
+  echo "${pants_version}"
+}
+
+function set_supported_python_versions {
+  local pants_version="$1"
+  local pants_major_version
+  local pants_minor_version
+  pants_major_version="$(echo "${pants_version}" | cut -d '.' -f1)"
+  pants_minor_version="$(echo "${pants_version}" | cut -d '.' -f2)"
+  if [[ "${pants_major_version}" -eq 1 ]]; then
+    supported_python_versions_decimal=('3.6' '3.7' '3.8')
+    supported_python_versions_int=('36' '37' '38')
+    supported_message='3.6, 3.7, or 3.8'
+  elif [[ "${pants_major_version}" -eq 2 && "${pants_minor_version}" -eq 0 ]]; then
+    supported_python_versions_decimal=('3.6' '3.7' '3.8')
+    supported_python_versions_int=('36' '37' '38')
+    supported_message='3.6, 3.7, or 3.8'
+  elif [[ "${pants_major_version}" -eq 2 && "${pants_minor_version}" -eq 1 ]]; then
+    supported_python_versions_decimal=('3.7' '3.8' '3.6')
+    supported_python_versions_int=('37' '38' '36')
+    supported_message='3.7, 3.8, or 3.6 (deprecated)'
+  elif [[ "${pants_major_version}" -eq 2 && "${pants_minor_version}" -lt 5 ]]; then
+    supported_python_versions_decimal=('3.8' '3.7')
+    supported_python_versions_int=('38' '37')
+    supported_message='3.7 or 3.8'
+  else
+    # We put 3.9 first because Apple Silicon only works properly with Python 3.9, even though it's possible to have
+    # older Pythons installed. This makes it more likely that Pants will work out-of-the-box.
+    supported_python_versions_decimal=('3.9' '3.8' '3.7')
+    supported_python_versions_int=('39' '38' '37')
+    supported_message='3.7, 3.8, or 3.9'
+  fi
+}
+
+function determine_default_python_exe {
+  for version in "${supported_python_versions_decimal[@]}"; do
+    local interpreter_path
+    interpreter_path="$(command -v "python${version}")"
+    if [[ -z "${interpreter_path}" ]]; then
+      continue
+    fi
+    # Check if the Python version is installed via Pyenv but not activated.
+    if [[ "$("${interpreter_path}" --version 2>&1 > /dev/null)" == "pyenv: python${version}"* ]]; then
+      continue
+    fi
+    echo "${interpreter_path}" && return 0
+  done
+}
+
+function determine_python_exe {
+  local pants_version="$1"
+  set_supported_python_versions "${pants_version}"
+  local requirement_str="For \`pants_version = \"${pants_version}\"\`, Pants requires Python ${supported_message} to run."
+
+  local python_bin_name
+  if [[ "${PYTHON_BIN_NAME}" != 'unspecified' ]]; then
+    python_bin_name="${PYTHON_BIN_NAME}"
+  else
+    python_bin_name="$(determine_default_python_exe)"
+    if [[ -z "${python_bin_name}" ]]; then
+      die "No valid Python interpreter found. ${requirement_str} Please check that a valid interpreter is installed and on your \$PATH."
+    fi
+  fi
+  local python_exe
+  python_exe="$(get_exe_path_or_die "${python_bin_name}")" || exit 1
+  local major_minor_version
+  major_minor_version="$(get_python_major_minor_version "${python_exe}")"
+  for valid_version in "${supported_python_versions_int[@]}"; do
+    if [[ "${major_minor_version}" == "${valid_version}" ]]; then
+      echo "${python_exe}" && return 0
+    fi
+  done
+  die "Invalid Python interpreter version for ${python_exe}. ${requirement_str}"
+}
+
+function compute_sha256 {
+  local python="$1"
+  local path="$2"
+
+  "$python" <<EOF
+import hashlib
+
+hasher = hashlib.sha256()
+with open('${path}', 'rb') as fp:
+    buf = fp.read()
+    hasher.update(buf)
+print(hasher.hexdigest())
+EOF
+}
+
+# TODO(John Sirois): GC race loser tmp dirs leftover from bootstrap_XXX
+# functions.  Any tmp dir w/o a symlink pointing to it can go.
+
+function bootstrap_pex {
+  local python="$1"
+  local bootstrapped="${PANTS_BOOTSTRAP}/pex-${PEX_VERSION}/pex"
+  if [[ ! -f "${bootstrapped}" ]]; then
+    (
+      green "Downloading the Pex PEX."
+      mkdir -p "${PANTS_BOOTSTRAP}"
+      local staging_dir
+      staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
+      cd "${staging_dir}"
+      curl -LO "${PEX_URL}"
+      fingerprint="$(compute_sha256 "${python}" "pex")"
+      if [[ "${PEX_EXPECTED_SHA256}" != "${fingerprint}" ]]; then
+        die "SHA256 of ${PEX_URL} is not as expected. Aborting."
+      fi
+      green "SHA256 fingerprint of ${PEX_URL} verified."
+      mkdir -p "$(dirname "${bootstrapped}")"
+      mv -f "${staging_dir}/pex" "${bootstrapped}"
+      rmdir "${staging_dir}"
+    ) 1>&2 || exit 1
+  fi
+  echo "${bootstrapped}"
+}
+
+function bootstrap_virtualenv {
+  local python="$1"
+  local bootstrapped="${PANTS_BOOTSTRAP}/virtualenv-${VIRTUALENV_VERSION}/virtualenv.pex"
+  if [[ ! -f "${bootstrapped}" ]]; then
+    (
+      green "Creating the virtualenv PEX."
+      pex_path="$(bootstrap_pex "${python}")" || exit 1
+      mkdir -p "${PANTS_BOOTSTRAP}"
+      local staging_dir
+      staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
+      cd "${staging_dir}"
+      echo "${VIRTUALENV_REQUIREMENTS}" > requirements.txt
+      "${python}" "${pex_path}" -r requirements.txt -c virtualenv -o virtualenv.pex
+      mkdir -p "$(dirname "${bootstrapped}")"
+      mv -f "${staging_dir}/virtualenv.pex" "${bootstrapped}"
+      rm -rf "${staging_dir}"
+    ) 1>&2 || exit 1
+  fi
+  echo "${bootstrapped}"
+}
+
+function find_links_url {
+  local pants_version="$1"
+  local pants_sha="$2"
+  echo -n "https://binaries.pantsbuild.org/wheels/pantsbuild.pants/${pants_sha}/${pants_version/+/%2B}/index.html"
+}
+
+function get_version_for_sha {
+  local sha="$1"
+
+  # Retrieve the Pants version associated with this commit.
+  local pants_version
+  pants_version="$(curl --fail -sL "https://raw.githubusercontent.com/pantsbuild/pants/${sha}/src/python/pants/VERSION")"
+
+  # Construct the version as the release version from src/python/pants/VERSION, plus the string `+gitXXXXXXXX`,
+  # where the XXXXXXXX is the first 8 characters of the SHA.
+  echo "${pants_version}+git${sha:0:8}"
+}
+
+function bootstrap_pants {
+  local pants_version="$1"
+  local python="$2"
+  local pants_sha="${3:-}"
+
+  local pants_requirement="pantsbuild.pants==${pants_version}"
+  local maybe_find_links
+  if [[ -z "${pants_sha}" ]]; then
+    maybe_find_links=""
+  else
+    maybe_find_links="--find-links=$(find_links_url "${pants_version}" "${pants_sha}")"
+   fi
+  local python_major_minor_version
+  python_major_minor_version="$(get_python_major_minor_version "${python}")"
+  local target_folder_name="${pants_version}_py${python_major_minor_version}"
+  local bootstrapped="${PANTS_BOOTSTRAP}/${target_folder_name}"
+
+  if [[ ! -d "${bootstrapped}" ]]; then
+    (
+      green "Bootstrapping Pants using ${python}"
+      local staging_dir
+      staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
+      local virtualenv_path
+      virtualenv_path="$(bootstrap_virtualenv "${python}")" || exit 1
+      green "Installing ${pants_requirement} into a virtual environment at ${bootstrapped}"
+      # shellcheck disable=SC2086
+      "${python}" "${virtualenv_path}" --no-download "${staging_dir}/install" && \
+      "${staging_dir}/install/bin/pip" install -U pip && \
+      "${staging_dir}/install/bin/pip" install ${maybe_find_links} --progress-bar off "${pants_requirement}" && \
+      ln -s "${staging_dir}/install" "${staging_dir}/${target_folder_name}" && \
+      mv "${staging_dir}/${target_folder_name}" "${bootstrapped}" && \
+      green "New virtual environment successfully created at ${bootstrapped}."
+    ) 1>&2 || exit 1
+  fi
+  echo "${bootstrapped}"
+}
+
+# Ensure we operate from the context of the ./pants buildroot.
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+pants_version="$(determine_pants_version)"
+python="$(determine_python_exe "${pants_version}")"
+pants_dir="$(bootstrap_pants "${pants_version}" "${python}" "${PANTS_SHA:-}")" || exit 1
+
+pants_python="${pants_dir}/bin/python"
+pants_binary="${pants_dir}/bin/pants"
+pants_extra_args=""
+if [[ -n "${PANTS_SHA:-}" ]]; then
+  pants_extra_args="${pants_extra_args} --python-repos-repos=$(find_links_url "$pants_version" "$PANTS_SHA")"
+fi
+
+# shellcheck disable=SC2086
+exec "${pants_python}" "${pants_binary}" ${pants_extra_args} \
+  --pants-bin-name="${PANTS_BIN_NAME}" --pants-version=${pants_version} "$@"

--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -1,0 +1,16 @@
+[GLOBAL]
+dynamic_ui = false
+colors = true
+
+# Since multiple jobs could run on the same Buildkite worker node, we
+# need to make sure the cache directories are isolated.
+local_store_dir = ".cache/pants/lmdb_store"
+named_caches_dir = ".cache/pants/named_caches"
+
+pants_ignore = [
+  ".cache/pants/named_caches",
+  ".cache/pants/lmdb_store",
+]
+
+[auth]
+from_env_var = "TOOLCHAIN_AUTH_TOKEN"

--- a/pants.toml
+++ b/pants.toml
@@ -1,0 +1,52 @@
+[GLOBAL]
+pants_version = "2.7.1"
+backend_packages = [
+    "pants.backend.shell",
+    "pants.backend.shell.lint.shellcheck",
+    "pants.backend.shell.lint.shfmt"
+]
+
+pants_ignore = [
+    "!.buildkite/"
+]
+
+plugins = [
+  "toolchain.pants.plugin==0.14.0"
+]
+
+remote_cache_read = true
+remote_cache_write = true
+remote_store_address = "grpcs://cache.toolchain.com:443"
+remote_auth_plugin = "toolchain.pants.auth.plugin:toolchain_auth_plugin"
+
+[toolchain-setup]
+repo = "cloudsmith-buildkite-plugin"
+
+[buildsense]
+enable = true
+
+# See https://www.pantsbuild.org/docs/anonymous-telemetry
+[anonymous-telemetry]
+enabled = true
+# Randomly generated with `uuidgen --random`
+repo_id = "00565d57-49c9-49ce-b082-4520e0946da8"
+
+[shfmt]
+# Indent with 4 spaces
+# Indent switch cases
+# Redirect operators are followed by a space
+args = ["-i 4", "-ci", "-sr"]
+
+[test]
+output = "all"
+
+[shellcheck]
+# Currently, Pants only knows about v0.7.1, but v0.7.2 has some nice
+# relative sourcing features we'd like to take advantage of (namely,
+# `script-path=SOURCEDIR`). Once Pants knows about v0.7.2 natively, we
+# can remove these configuration values.
+version = "v0.7.2"
+known_versions = [
+  "v0.7.2|macos_x86_64|969bd7ef668e8167cfbba569fb9f4a0b2fc1c4021f87032b6a0b0e525fb77369|3988092",
+  "v0.7.2|linux_x86_64|70423609f27b504d6c0c47e340f33652aea975e45f312324f2dbf91c95a3b188|1382204"
+]

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,0 +1,61 @@
+---
+name: cloudsmith
+description: Interact with Cloudsmith package repositories
+author: https://github.com/grapl-security
+requirements:
+  - docker
+  - jq
+configuration:
+  properties:
+    image:
+      description: |
+        The `cloudsmith-cli` image to use; defaults to
+        `docker.cloudsmith.io/grapl/releases/cloudsmith-cli` (there
+        isn't an official one yet).
+      type: string
+    tag:
+      description: |
+        The cloudsmith-cli image to use; defaults to `latest`.
+      type: string
+    promote:
+      description: |
+        Configuration for package promotions from one repository to
+        another.
+      type: object
+      properties:
+        org:
+          description: |
+            The Cloudsmith organization to interact with.
+          type: string
+        from:
+          description: |
+            The repository to promote packages from. It must be within
+            the configured organization.
+          type: string
+        to:
+          description: |
+            The repository to promote packages to. It must also be
+            within the configured organization.
+          type: string
+        packages:
+          description: |
+            A mapping of package name to package version. These will
+            be the packages that are promoted.
+          type: object
+        packages_file:
+          description: |
+            A file to read packages from. Contains a JSON object of
+            the same structure as the `packages` key. Preferred over
+            `packages` if both are present.
+          type: string
+      allOf:
+        - required: [org, from, to]
+        - oneOf:
+            # One of `packages` or `packages_file` is required, but
+            # not both, and not neither.
+            - required: [packages]
+            - required: [packages_file]
+  # For now, "promote" is required. We'll leave "space" in the
+  # configuration for future operations.
+  required: [promote]
+  additionalProperties: false


### PR DESCRIPTION
Adds plugin code to promote packages from one repository to another.

To test, we actually push a test container to a dedicated testing
repository, promote it to another testing repository, and then verify
that the package was indeed moved. (These repositories are configured
to automatically delete packages older than 1 day).

Extensive documentation is available in the README, as well as in the
various unit tests.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>