### PR TITLE
Add merge pipeline 

### DIFF
--- a/.buildkite/pipeline.merge.build-container.yml
+++ b/.buildkite/pipeline.merge.build-container.yml
@@ -1,51 +1,32 @@
+---
 env:
   PANTS_CONFIG_FILES: "['pants.toml', 'pants.ci.toml']"
   BUILDKITE_PLUGIN_VAULT_ENV_SECRET_PREFIX: "secret/data/buildkite/env"
 
 steps:
-
-  - label: ":lint-roller::bash: Lint Bash"
+  - label: ":cloudsmith::docker: Upload new Cloudsmith container"
     command:
-      - make lint-bash
+      - make image-push
     plugins:
       - grapl-security/vault-login#v0.1.0
       - grapl-security/vault-env#v0.1.0:
           secrets:
-            - cloudsmith-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN
-
-  - label: ":lint-roller::docker: Lint Dockerfile"
-    command:
-      - make lint-docker
-
-  - label: ":lint-roller: Lint HCL"
-    command:
-      - make lint-hcl
-
-  - label: ":lint-roller::buildkite: Lint Plugin"
-    command:
-      - make lint-plugin
-
-  - label: ":bash: Unit Test Bash"
-    command:
-      - make test-bash
-    plugins:
-      - grapl-security/vault-login#v0.1.0
-      - grapl-security/vault-env#v0.1.0:
-          secrets:
-            - cloudsmith-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN
-
-  - label: ":docker: Build Image"
-    command:
-      - make image
-
-  ########################################################################
+            - CLOUDSMITH_API_KEY
+      - docker-login#v2.0.1:
+          username: grapl-cicd
+          password-env: CLOUDSMITH_API_KEY
+          server: docker.cloudsmith.io
+    agents:
+      queue: "docker"
 
   - wait
+
+  # Re-run validation with the new image, just to be safe.
 
   - label: ":cloudsmith::docker: Upload testing container"
     key: test-upload
     command:
-      - docker buildx bake verify-image --file=docker-bake.testing.hcl --push
+      - docker buildx bake merge-image --file=docker-bake.testing.hcl --push
     plugins:
       - grapl-security/vault-login#v0.1.0
       - grapl-security/vault-env#v0.1.0:
@@ -67,28 +48,47 @@ steps:
           secrets:
             - CLOUDSMITH_API_KEY
       - grapl-security/cloudsmith#${BUILDKITE_COMMIT}:
-          # See contents of the `verify-image` target in
-          # `docker-bake.testing.hcl` for where these values come
-          # from.
+          # See contents of the `merge-image` target in
+          # `docker-bake.testing.hcl` for where these values come from.
           promote:
+            # Use the image we just built to drive this
+            image: docker.cloudsmith.io/grapl/raw/cloudsmith-cli
+            tag: latest
             org: grapl
             from: testing-stage1
             to: testing-stage2
             packages:
-              cloudsmith-buildkite-plugin-verify-test: ${BUILDKITE_BUILD_ID}
+              cloudsmith-buildkite-plugin-merge-test: ${BUILDKITE_BUILD_ID}
     agents:
       queue: "docker"  # could also be artifact-uploaders
-
 
   - label: ":cloudsmith::white_check_mark: Verify Promotion"
     key: verify-promotion
     depends_on: promotion-test
     command:
-      - .buildkite/scripts/verify_promotion.sh "cloudsmith-buildkite-plugin-verify-test"
+      - .buildkite/scripts/verify_promotion.sh "cloudsmith-buildkite-plugin-merge-test"
     plugins:
       - grapl-security/vault-login#v0.1.0
       - grapl-security/vault-env#v0.1.0:
           secrets:
             - CLOUDSMITH_API_KEY
+    agents:
+      queue: "docker"  # could also be artifact-uploaders
+
+  - wait
+
+  - label: ":cloudsmith::buildkite: Promote new cloudsmith-cli image"
+    plugins:
+      - grapl-security/vault-login#v0.1.0
+      - grapl-security/vault-env#v0.1.0:
+          secrets:
+            - CLOUDSMITH_API_KEY
+      - grapl-security/cloudsmith#v0.1.0:
+          promote:
+            org: grapl
+            from: raw
+            to: releases
+            packages:
+              cloudsmith-cli: latest
     agents:
       queue: "docker"  # could also be artifact-uploaders

--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -1,0 +1,25 @@
+---
+env:
+  PANTS_CONFIG_FILES: "['pants.toml', 'pants.ci.toml']"
+  BUILDKITE_PLUGIN_VAULT_ENV_SECRET_PREFIX: "secret/data/buildkite/env"
+
+steps:
+
+  - label: ":thinking_face: Build Cloudsmith Container?"
+    plugins:
+      - chronotc/monorepo-diff#v2.0.4:
+          diff: .buildkite/shared/scripts/diff.sh
+          log_level: "debug"
+          watch:
+            - path:
+                - Dockerfile
+                - docker-bake.hcl
+              config:
+                label: ":pipeline: Upload pipeline"
+                command: "buildkite-agent pipeline upload .buildkite/pipeline.merge.build-container.yml"
+
+  - wait
+
+  - label: ":writing_hand: Record successful build"
+    command:
+      - .buildkite/shared/steps/record_successful_pipeline_run.sh

--- a/.buildkite/scripts/verify_promotion.sh
+++ b/.buildkite/scripts/verify_promotion.sh
@@ -13,7 +13,13 @@ source "$(dirname "${BASH_SOURCE[0]}")/../../lib/ops.sh"
 # shellcheck source-path=SCRIPTDIR
 source "$(dirname "${BASH_SOURCE[0]}")/../../lib/log.sh"
 
-readonly image_name="cloudsmith-buildkite-plugin-verify-test"
+# The particular image we're querying will depend on whether we're in
+# the verify pipeline or the merge pipeline; see
+# docker-bake.testing.hcl for possible values.
+readonly image_name="${1}"
+
+# All images are expected to be tagged with the current build ID,
+# however (also defined in docker-bake.testing.hcl).
 readonly image_tag="${BUILDKITE_BUILD_ID}"
 readonly fully_qualified_image_name="${image_name}:${image_tag}"
 

--- a/.buildkite/shared/.buildkite/pipeline.verify.yml
+++ b/.buildkite/shared/.buildkite/pipeline.verify.yml
@@ -1,0 +1,23 @@
+---
+env:
+  PANTS_CONFIG_FILES: "['pants.toml', 'pants.ci.toml']"
+  BUILDKITE_PLUGIN_VAULT_ENV_SECRET_PREFIX: "secret/data/buildkite/env"
+
+steps:
+  - label: ":bash: Linting"
+    command:
+      - "./pants lint ::"
+    plugins:
+      - grapl-security/vault-login#v0.1.0
+      - grapl-security/vault-env#v0.1.0:
+          secrets:
+            - buildkite-common/TOOLCHAIN_AUTH_TOKEN
+
+  - label: ":bash: Testing"
+    command:
+      - "./pants test ::"
+    plugins:
+      - grapl-security/vault-login#v0.1.0
+      - grapl-security/vault-env#v0.1.0:
+          secrets:
+            - buildkite-common/TOOLCHAIN_AUTH_TOKEN

--- a/.buildkite/shared/.gitignore
+++ b/.buildkite/shared/.gitignore
@@ -1,0 +1,9 @@
+# Pants-related artifacts
+# https://www.pantsbuild.org/docs/gitignore
+########################################################################
+/.pants.d/
+/dist/
+/.pids
+/.pants.workdir.file_lock*
+
+.envrc

--- a/.buildkite/shared/lib/BUILD
+++ b/.buildkite/shared/lib/BUILD
@@ -1,0 +1,7 @@
+shell_library()
+
+shunit2_tests(
+    name="tests",
+    # Currently using relative imports for tests, which aren't visible to Pants
+    dependencies=[":lib"]
+)

--- a/.buildkite/shared/lib/json_tools.sh
+++ b/.buildkite/shared/lib/json_tools.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+flatten_json() {
+    # The purpose of this module is to convert something like the following json:
+    # {
+    #     "some-amis": {
+    #         "us-east-1": "ami-111",
+    #     }
+    # }
+    # into { "some-amis.us-east-1": "ami-111" }
+
+    local -r input_json="${1}"
+    # https://stackoverflow.com/a/37557003
+    jq -r '
+        . as $in
+        | reduce paths(scalars) as $path (
+            {};
+            . + { ($path | map(tostring) | join(".")): $in | getpath($path) }
+        )
+    ' <<< "${input_json}"
+}

--- a/.buildkite/shared/lib/pulumi.sh
+++ b/.buildkite/shared/lib/pulumi.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+# Pulumi Helper Functions
+
+# All our Pulumi projects exist in our single organization.
+readonly PULUMI_ORG="grapl"
+
+# By convention, all of our Pulumi code exists in the `pulumi`
+# directory in the repository root
+readonly PULUMI_DIR="pulumi"
+
+# When managing multiple projects and their stacks, we'll pass around
+# qualified names in the form of `project/stack`. This is a shortened
+# version of the fully-qualified name that Pulumi uses of
+# `organization/project/stack`.
+#
+# Because of how we are currently organizing the code for our
+# projects, they are stored in directories that are valid Python
+# module names (specifically, they use underscores rather than
+# hyphens). The formal project name in Pulumi, however, uses hyphens
+# instead of underscores (mainly for cosmetic purposes, avoiding a
+# mixture of hyphens and underscores in various generated names).
+#
+# We can account for this distinction with helper functions.
+
+# Extract the project name from a "project/stack" pair.
+#
+#     split_project "foo/bar"
+#     # => foo
+#
+split_project() {
+    local -r input="${1}"
+    cut --only-delimited --fields=1 --delimiter=/ <<< "${input}"
+}
+
+# Extract the stack name from a "project/stack" pair.
+#
+#     split_project "foo/bar"
+#     # => bar
+#
+split_stack() {
+    local -r input="${1}"
+    cut --only-delimited --fields=2 --delimiter=/ <<< "${input}"
+}
+
+# Expands a project/stack name into the full, organization-qualified
+# one.
+#
+# This will be used for the `--stack` value in various `pulumi` CLI
+# invocations. Technically (since the project is already determined
+# from the directory `pulumi` is invoked from), this can simply be of
+# the form "<ORGANIZATION>/<STACK>", but
+# "<ORGANIZATION>/<PROJECT>/<STACK>" is also accepted.
+#
+# So we don't have to come up with a distinction between the two- and
+# three-part forms (and a three-part form is arguably "more fully"
+# qualified anyway), we'll just conventionally use the three-part one.
+#
+#     fully_qualified_stack_name "foo/bar"
+#     # => grapl/foo/bar
+#
+fully_qualified_stack_name() {
+    local -r input="${1}"
+    local -r project="$(split_project "${input}")"
+    local -r stack="$(split_stack "${input}")"
+    echo "${PULUMI_ORG}/${project}/${stack}"
+}
+
+# Returns the full path (from the repository root) of the directory
+# for the given Pulumi project.
+#
+#     project_directory "foo-bar/testing"
+#     # => pulumi/foo_bar
+#
+project_directory() {
+    local -r input="${1}"
+    local -r dir_name="$(split_project "${input}" | tr - _)"
+    echo "${PULUMI_DIR}/${dir_name}"
+}
+
+# Expand a project/stack name into the full path (from the root of the
+# repository) to its corresponding configuration file.
+#
+#     stack_file_path "foo-bar/testing"
+#     # => pulumi/foo_bar/Pulumi.testing.yaml
+#
+stack_file_path() {
+    local -r input="${1}"
+
+    local -r project_dir="$(project_directory "${input}")"
+    local -r stack="$(split_stack "${input}")"
+
+    echo "${project_dir}/Pulumi.${stack}.yaml"
+}

--- a/.buildkite/shared/lib/pulumi_test.sh
+++ b/.buildkite/shared/lib/pulumi_test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+oneTimeSetUp() {
+    # shellcheck source-path=SCRIPTDIR
+    source "$(dirname "${BASH_SOURCE[0]}")/pulumi.sh"
+}
+
+test_split_project() {
+    assertEquals "project" "$(split_project "project/stack")"
+}
+
+test_split_stack() {
+    assertEquals "stack" "$(split_stack "project/stack")"
+}
+
+test_fully_qualified_stack_name() {
+    assertEquals "grapl/cicd/production" "$(fully_qualified_stack_name cicd/production)"
+}
+
+test_project_directory() {
+    assertEquals "pulumi/project" "$(project_directory "project/stack")"
+    assertEquals "pulumi/foo_bar" "$(project_directory "foo-bar/stack")"
+    assertEquals "pulumi/foo_bar_baz_quux" "$(project_directory "foo-bar-baz-quux/stack")"
+    assertEquals "pulumi/boo_baz" "$(project_directory "boo_baz/stack")"
+}
+
+test_stack_file_path() {
+    assertEquals "pulumi/foo_bar/Pulumi.testing.yaml" "$(stack_file_path "foo-bar/testing")"
+}

--- a/.buildkite/shared/lib/rc.sh
+++ b/.buildkite/shared/lib/rc.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")/json_tools.sh"
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")/util.sh"
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")/pulumi.sh"
+
+# Given a project and stack name, and a flat JSON object as an input
+# string, adds each key-value pair the Pulumi configuration for that
+# stack.
+#
+# Input of "cicd", "production", '{"foo":"123","bar":"456"}' would end up running:
+#
+#     pulumi config set --path "artifacts.foo" "123" --cwd=pulumi/cicd --stack=grapl/production
+#     pulumi config set --path "artifacts.bar" "456" --cwd=pulumi/cicd --stack=grapl/production
+#
+
+add_artifacts() {
+    local -r stack="${1}"
+    local -r input_json="${2}"
+
+    flattened_input_json=$(flatten_json "${input_json}")
+
+    jq -r 'to_entries | .[] | [.key, .value] | @tsv' <<< "${flattened_input_json}" |
+        while IFS=$'\t' read -r key value; do
+            pulumi config set \
+                --path "artifacts.${key}" \
+                "${value}" \
+                --cwd="$(project_directory "${stack}")" \
+                --stack="$(fully_qualified_stack_name "${stack}")"
+        done
+}
+
+# Generate a commit message for this containing metadata about the
+# artifacts that were updated, if any.
+commit_message() {
+    local -r input_json="${1}"
+
+    if had_new_artifacts "${input_json}"; then
+        echo "Create new release candidate with updated deployment artifacts"
+        echo
+        echo "Updated the following artifact versions:"
+        echo
+        jq -r '
+        to_entries | .[] |
+        "- " + .key + " => " + .value
+        ' <<< "${input_json}"
+    else
+        echo "Create new release candidate"
+    fi
+    echo
+    echo "Generated from ${BUILDKITE_BUILD_URL}"
+}
+
+had_new_artifacts() {
+    local -r input_json="${1}"
+    num_artifacts=$(jq 'length' <<< "${input_json}")
+    if (("${num_artifacts}" == 0)); then
+        return 1
+    fi
+    return 0
+}
+
+# Returns a JSON object for the `artifacts` configuration key in the
+# given project and stack, or `{}` if the key is not present.
+#
+# By convention, we store all our pinned artifact versions in Pulumi
+# config in this manner.
+existing_artifacts() {
+    local -r stack="${1}"
+
+    pulumi config get artifacts \
+        --cwd="$(project_directory "${stack}")" \
+        --stack="$(fully_qualified_stack_name "${stack}")" ||
+        echo "{}"
+}
+
+# Given a short stack name and a flat JSON object of artifact-version
+# pairs:
+#
+# - merges any configuration changes for the stack from `main` into
+#   `rc`
+# - preserves any artifact versions that were previously specified
+#   on `rc`
+# - Adds the new artifacts from this pipeline run to the stack
+#   configuration
+# - Adds the updated stack configuration to the git staging area
+#
+# Assumes that we are currently on the `rc` branch, and are always
+# pulling core config updates from the `main` branch.
+#
+update_stack_config_for_commit() {
+    local -r project_stack="${1}"
+    local -r new_artifacts="${2}"
+
+    local -r stack_file="$(stack_file_path "${project_stack}")"
+
+    # First, we want to preserve any artifact versions that are
+    #already in the `rc` branch.
+    echo -e "--- Extracting pinned artifact versions from rc branch"
+    existing_rc_artifacts="$(existing_artifacts "${project_stack}")"
+    jq '.' <<< "${existing_rc_artifacts}"
+
+    # Now that we've captured the artifact versions from this version
+    # of the config file, we'll copy back the original contents of the
+    # config from the `main` branch.
+    #
+    # The idea is that if we add new, non-artifact configuration during
+    # the course of normal development, we want to carry that over to the
+    # `rc` branch.
+    echo -e "--- Restoring config file from main branch"
+    git show "main:${stack_file}" > "${stack_file}"
+    cat "${stack_file}"
+
+    # Now that we have our base configuration reestablished, we need
+    # to add back the artifact versions that were on the `rc` branch
+    # already.
+    echo -e "--- Adding pinned artifacts back to config file"
+    add_artifacts "${project_stack}" "${existing_rc_artifacts}"
+    cat "${stack_file}"
+
+    # Finally, we can layer on any new or updated artifact versions that
+    # were generated in *this build*. This line is the point of this
+    # entire script.
+    echo -e "--- Adding new artifact pins to config file"
+    add_artifacts "${project_stack}" "${new_artifacts}"
+    cat "${stack_file}"
+
+    # Add the updated configuration file to our already-in-progress merge
+    # commit.
+    echo -e "--- :git: Adding config file to in-progress merge commit"
+    git add --verbose "${stack_file}"
+}
+
+create_rc() {
+    # This fundamentally assumes that we're running on the main branch!
+
+    # A JSON object string
+    local -r new_artifacts="${1}"
+
+    # All other arguments are all the "project/stack" config files to
+    # update.
+    shift
+    local -ra stacks=("${@}")
+
+    # We have to log in before we can update any configuration values.
+    echo -e "--- :pulumi: Logging in to Pulumi"
+    pulumi login
+
+    echo -e "--- :git: Checking out the rc branch"
+    git checkout rc
+
+    echo -e "--- :git: Begin merge of main branch to rc"
+    # TODO: For some as-yet unknown reason, it appears that we MUST
+    # set the author and email in a config file for it to take
+    # effect. Simply having the values in the environment doesn't
+    # work, nor does specifying a value at commit-time with
+    # `--author`.
+    git config user.name "${GIT_AUTHOR_NAME}"
+    git config user.email "${GIT_AUTHOR_EMAIL}"
+
+    # We use the recursive/theirs strategy here to preserve the
+    # conflicts from the rc branch preferentially (this should only
+    # involve the Pulumi stack config files, which is exactly what we
+    # want). As we process the files further, we'll resolve any
+    # semantic changes we truly wish to preserve.
+    git merge \
+        --no-ff \
+        --no-commit \
+        --strategy=recursive \
+        --strategy-option=ours \
+        main
+
+    for stack in "${stacks[@]}"; do
+        update_stack_config_for_commit "${stack}" "${new_artifacts}"
+    done
+
+    # Finalize the commit, with a helpful, metadata-laden commit message.
+    echo -e "--- :git: Finalizing commit"
+    git commit \
+        --message="$(commit_message "${new_artifacts}")"
+    git --no-pager show
+
+    # Finally, push it up to Github!
+    if is_real_run; then
+        echo -e "--- :github: Pushing rc branch to Github"
+        git push --verbose
+    else
+        echo -e "--- :no_good: Would have pushed rc branch to Github"
+    fi
+}

--- a/.buildkite/shared/lib/rc_test.sh
+++ b/.buildkite/shared/lib/rc_test.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+
+# mock `pulumi` binary
+#
+# This prevents the actual `pulumi` binary from being executed during
+# these tests. Every invocation is logged to a file.
+#
+# To make assertions, simply inspect the contents of the file to
+# ensure that the expected commands _would_ have been invoked.
+#
+# In the case of the `pulumi config get artifacts`, we actually do
+# need to simulate a functioning binary. In that case, the behavior is
+# governed by the $EXISTING_ARTIFACTS environment variable, which may
+# be set in a test. If it is not present, the command errors out, as
+# it would in "real life". If it is present, its value is returned.
+pulumi() {
+    echo "${FUNCNAME[0]} $*" >> "${ALL_COMMANDS}"
+
+    case "$*" in
+        config\ get\ artifacts*)
+            # Expects EXISTING_ARTIFACTS to be a valid, non-empty JSON object
+            if [ -n "${EXISTING_ARTIFACTS:-}" ]; then
+                echo "${EXISTING_ARTIFACTS}"
+            else
+                # Simulates the error condition where the expected
+                # config key was not present
+                return 255
+            fi
+            ;;
+        *) ;;
+    esac
+}
+
+# Simple git binary mock that just records its invocations
+git() {
+    echo "${FUNCNAME[0]} $*" >> "${ALL_COMMANDS}"
+}
+
+recorded_commands() {
+    if [ -f "${ALL_COMMANDS}" ]; then
+        cat "${ALL_COMMANDS}"
+    fi
+}
+
+oneTimeSetUp() {
+    export BUILDKITE_BUILD_URL="https://buildkite.com/grapl/pipeline-infrastructure-verify/builds/2112"
+    export ALL_COMMANDS="${SHUNIT_TMPDIR}/all_commands"
+    export GIT_AUTHOR_NAME="Testy McTestface"
+    export GIT_AUTHOR_EMAIL="tests@tests.com"
+
+    # shellcheck source-path=SCRIPTDIR
+    source "$(dirname "${BASH_SOURCE[0]}")/rc.sh"
+}
+
+setUp() {
+    # Ensure any recorded commands from the last test are removed so
+    # we start with a clean slate.
+    rm -f "${ALL_COMMANDS}"
+
+    # Some functions under test assume they are running from the
+    # repository root, and will have a `pulumi` directory present,
+    # along with individual project directories within. We run these
+    # tests through Pants, which copies the test files into an
+    # isolated temporary directory for execution. Importantly, this
+    # directory does not have any of these subdirectories.
+    #
+    # To enable those tests to run, well just create them. At this
+    # time, we don't actually need any of the files.
+    mkdir -p pulumi/cicd
+}
+
+tearDown() {
+    rm -Rf pulumi
+}
+
+test_add_artifacts_with_artifacts() {
+    add_artifacts cicd/production '{"app1":"v1.0.0","app2":"v1.2.0","nested_map":{"k":"v"}}'
+
+    expected=$(
+        cat << EOF
+pulumi config set --path artifacts.app1 v1.0.0 --cwd=pulumi/cicd --stack=grapl/cicd/production
+pulumi config set --path artifacts.app2 v1.2.0 --cwd=pulumi/cicd --stack=grapl/cicd/production
+pulumi config set --path artifacts.nested_map.k v --cwd=pulumi/cicd --stack=grapl/cicd/production
+EOF
+    )
+
+    assertEquals "The expected pulumi commands were not run" \
+        "${expected}" \
+        "$(recorded_commands)"
+}
+
+test_add_artifacts_without_artifacts() {
+    add_artifacts cicd/production '{}'
+    assertNull "Should not have run any pulumi commands" \
+        "$(recorded_commands)"
+}
+
+# Ensure we generate a commit message with information about the
+# artifacts generated during this pipeline run.
+test_commit_message_with_artifacts() {
+    actual="$(commit_message '{"app1":"v1.0.0","app2":"v2.0.0"}')"
+    expected=$(
+        cat << EOF
+Create new release candidate with updated deployment artifacts
+
+Updated the following artifact versions:
+
+- app1 => v1.0.0
+- app2 => v2.0.0
+
+Generated from https://buildkite.com/grapl/pipeline-infrastructure-verify/builds/2112
+EOF
+    )
+    assertEquals "${expected}" "${actual}"
+}
+
+# Ensure we generate a sane commit message even if we don't generate
+# any new artifacts during this pipeline run.
+test_commit_message_without_artifacts() {
+    actual="$(commit_message '{}')"
+    expected=$(
+        cat << EOF
+Create new release candidate
+
+Generated from https://buildkite.com/grapl/pipeline-infrastructure-verify/builds/2112
+EOF
+    )
+    assertEquals "${expected}" "${actual}"
+}
+
+test_had_new_artifacts() {
+    input='{"app1":"v6.6.6"}'
+    assertTrue "A JSON object with keys should 'have artifacts'" \
+        "had_new_artifacts ${input}"
+
+    input='{}'
+    assertFalse "An empty JSON object has no artifacts" \
+        "had_new_artifacts ${input}"
+}
+
+test_existing_artifacts_with_artifacts() {
+    actual="$(EXISTING_ARTIFACTS='{"app1":"v1.0.0"}' existing_artifacts cicd/production)"
+    assertEquals '{"app1":"v1.0.0"}' "${actual}"
+    assertEquals \
+        "pulumi config get artifacts --cwd=pulumi/cicd --stack=grapl/cicd/production" \
+        "$(recorded_commands)"
+}
+
+test_existing_artifacts_without_artifacts() {
+    actual="$(existing_artifacts cicd/production)"
+    assertEquals "{}" "${actual}"
+    assertEquals \
+        "pulumi config get artifacts --cwd=pulumi/cicd --stack=grapl/cicd/production" \
+        "$(recorded_commands)"
+}
+
+test_update_stack_config_for_commit_with_new_artifacts_without_existing() {
+    update_stack_config_for_commit "cicd/production" '{"app1":"v9.9.9","app2":"v1.0alpha"}'
+
+    expected=$(
+        cat << EOF
+pulumi config get artifacts --cwd=pulumi/cicd --stack=grapl/cicd/production
+git show main:pulumi/cicd/Pulumi.production.yaml
+pulumi config set --path artifacts.app1 v9.9.9 --cwd=pulumi/cicd --stack=grapl/cicd/production
+pulumi config set --path artifacts.app2 v1.0alpha --cwd=pulumi/cicd --stack=grapl/cicd/production
+git add --verbose pulumi/cicd/Pulumi.production.yaml
+EOF
+    )
+
+    assertEquals "${expected}" "$(recorded_commands)"
+}
+
+test_update_stack_config_for_commit_without_new_artifacts_without_existing() {
+    update_stack_config_for_commit "cicd/production" '{}'
+
+    expected=$(
+        cat << EOF
+pulumi config get artifacts --cwd=pulumi/cicd --stack=grapl/cicd/production
+git show main:pulumi/cicd/Pulumi.production.yaml
+git add --verbose pulumi/cicd/Pulumi.production.yaml
+EOF
+    )
+
+    assertEquals "${expected}" "$(recorded_commands)"
+}
+
+test_update_stack_config_for_commit_with_new_artifacts_with_existing() {
+    (
+        EXISTING_ARTIFACTS='{"app1":"v9.9.8","app3":"0.0.1"}'
+        update_stack_config_for_commit "cicd/production" '{"app1":"v9.9.9","app2":"v1.0alpha"}'
+    )
+
+    expected=$(
+        cat << EOF
+pulumi config get artifacts --cwd=pulumi/cicd --stack=grapl/cicd/production
+git show main:pulumi/cicd/Pulumi.production.yaml
+pulumi config set --path artifacts.app1 v9.9.8 --cwd=pulumi/cicd --stack=grapl/cicd/production
+pulumi config set --path artifacts.app3 0.0.1 --cwd=pulumi/cicd --stack=grapl/cicd/production
+pulumi config set --path artifacts.app1 v9.9.9 --cwd=pulumi/cicd --stack=grapl/cicd/production
+pulumi config set --path artifacts.app2 v1.0alpha --cwd=pulumi/cicd --stack=grapl/cicd/production
+git add --verbose pulumi/cicd/Pulumi.production.yaml
+EOF
+    )
+
+    assertEquals "${expected}" "$(recorded_commands)"
+}
+
+test_update_stack_config_for_commit_without_new_artifacts_with_existing() {
+    (
+        EXISTING_ARTIFACTS='{"app1":"v9.9.8","app3":"0.0.1"}'
+        update_stack_config_for_commit "cicd/production" '{}'
+    )
+
+    expected=$(
+        cat << EOF
+pulumi config get artifacts --cwd=pulumi/cicd --stack=grapl/cicd/production
+git show main:pulumi/cicd/Pulumi.production.yaml
+pulumi config set --path artifacts.app1 v9.9.8 --cwd=pulumi/cicd --stack=grapl/cicd/production
+pulumi config set --path artifacts.app3 0.0.1 --cwd=pulumi/cicd --stack=grapl/cicd/production
+git add --verbose pulumi/cicd/Pulumi.production.yaml
+EOF
+    )
+
+    assertEquals "${expected}" "$(recorded_commands)"
+}
+
+test_create_rc_webhook() {
+    (
+        BUILDKITE_SOURCE=webhook
+        create_rc "{}" cicd/production cicd/testing
+    )
+
+    expected=$(
+        cat << EOF
+pulumi login
+git checkout rc
+git config user.name Testy McTestface
+git config user.email tests@tests.com
+git merge --no-ff --no-commit --strategy=recursive --strategy-option=ours main
+pulumi config get artifacts --cwd=pulumi/cicd --stack=grapl/cicd/production
+git show main:pulumi/cicd/Pulumi.production.yaml
+git add --verbose pulumi/cicd/Pulumi.production.yaml
+pulumi config get artifacts --cwd=pulumi/cicd --stack=grapl/cicd/testing
+git show main:pulumi/cicd/Pulumi.testing.yaml
+git add --verbose pulumi/cicd/Pulumi.testing.yaml
+git commit --message=Create new release candidate
+
+Generated from https://buildkite.com/grapl/pipeline-infrastructure-verify/builds/2112
+git --no-pager show
+git push --verbose
+EOF
+    )
+
+    assertEquals "${expected}" "$(recorded_commands)"
+}
+
+test_create_rc_ui_no_override() {
+    (
+        BUILDKITE_SOURCE=ui
+        create_rc "{}" cicd/production cicd/testing
+    )
+    assertNotContains "Shouldn't push to git if this is a UI job" \
+        "$(recorded_commands)" \
+        "git push --verbose"
+}
+
+test_create_rc_ui_with_override() {
+    (
+        BUILDKITE_SOURCE=ui
+        BREAK_GLASS_IN_CASE_OF_EMERGENCY=1
+        create_rc "{}" cicd/production cicd/testing
+    )
+    assertContains "Should push to git even though this is a UI job" \
+        "$(recorded_commands)" \
+        "git push --verbose"
+}

--- a/.buildkite/shared/lib/record.sh
+++ b/.buildkite/shared/lib/record.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Assuming our pipeline names are of the form of:
+#
+#     REPOSITORY_NAME/PIPELINE
+#
+# extracts the PIPELINE portion.
+#
+#     export BUILDKITE_PIPELINE_NAME=pipeline-infrastructure/merge
+#     pipeline_from_env
+#     # => merge
+#
+pipeline_from_env() {
+    echo "${BUILDKITE_PIPELINE_NAME##*/}"
+}
+
+# The lightweight Git tag we'll use to record which commit was the
+# last to successfully make it through the given pipeline. This will
+# be updated with every passing pipeline run. As such, it is
+# explicitly for internal use, and any dependence on the commit it
+# refers to remaining constant is WRONG.
+#
+#     tag_for_pipeline merge
+#     # => internal/last-successful-merge
+#
+tag_for_pipeline() {
+    local -r pipeline="${1}"
+    echo "internal/last-successful-${pipeline}"
+}
+
+# Update the tag for the given pipeline to the current commit and push
+# it to Github.
+tag_last_success() {
+    local -r pipeline="${1}"
+    local -r tag="$(tag_for_pipeline "${pipeline}")"
+
+    echo "--- :github: Re-tagging '${tag}'"
+    git tag "${tag}" --force
+    echo "--- :github: Pushing new value for '${tag}' tag"
+    git push origin "${tag}" --force --verbose
+}

--- a/.buildkite/shared/lib/record_test.sh
+++ b/.buildkite/shared/lib/record_test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Simple git binary mock that just records its invocations
+git() {
+    echo "${FUNCNAME[0]} $*" >> "${ALL_COMMANDS}"
+}
+
+recorded_commands() {
+    if [ -f "${ALL_COMMANDS}" ]; then
+        cat "${ALL_COMMANDS}"
+    fi
+}
+
+oneTimeSetUp() {
+    export ALL_COMMANDS="${SHUNIT_TMPDIR}/all_commands"
+    # shellcheck source-path=SCRIPTDIR
+    source "$(dirname "${BASH_SOURCE[0]}")/record.sh"
+}
+
+test_pipeline_from_env() {
+    actual="$(BUILDKITE_PIPELINE_NAME=pipeline-infrastructure/merge pipeline_from_env)"
+
+    assertEquals "Failed to extract a pipeline key from BUILDKITE_PIPELINE_NAME" \
+        "merge" \
+        "${actual}"
+}
+
+test_tag_for_pipeline() {
+    assertEquals "internal/last-successful-merge" "$(tag_for_pipeline merge)"
+    assertEquals "internal/last-successful-provision" "$(tag_for_pipeline provision)"
+}
+
+test_tag_last_success() {
+
+    tag_last_success "merge"
+
+    expected=$(
+        cat << EOF
+git tag internal/last-successful-merge --force
+git push origin internal/last-successful-merge --force --verbose
+EOF
+    )
+
+    assertEquals "The expected git commands were not run" \
+        "${expected}" \
+        "$(recorded_commands)"
+}

--- a/.buildkite/shared/lib/util.sh
+++ b/.buildkite/shared/lib/util.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Determines whether this pipeline run is "real" or if it was an
+# ad-hoc one triggered by a person for testing. If the latter, there
+# are some actions that we don't want to perform (such as pushing a
+# new merge commit to an `rc` branch, performing a release, etc.).
+#
+# In the rare case that a human *does* need to legitimately run a
+# pipeline *as though it were a real run*, then the
+# `BREAK_GLASS_IN_CASE_OF_EMERGENCY` environment variable should be
+# set.
+#
+# Hinges on the value of `BUILDKITE_SOURCE`; see
+# https://buildkite.com/docs/pipelines/environment-variables#bk-env-vars-buildkite-source
+# for details.
+is_real_run() {
+    case "${BUILDKITE_SOURCE}" in
+        webhook | api | trigger_job | schedule)
+            true
+            ;;
+        ui)
+            if [ -n "${BREAK_GLASS_IN_CASE_OF_EMERGENCY:-}" ]; then
+                true
+            else
+                false
+            fi
+            ;;
+        *)
+            echo "--- :exclamation_mark: Unrecognized BUILDKITE_SOURCE: ${BUILDKITE_SOURCE}; cowardly refusing to consider this run \"real\""
+            false
+            ;;
+    esac
+}

--- a/.buildkite/shared/lib/util_test.sh
+++ b/.buildkite/shared/lib/util_test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+oneTimeSetUp() {
+    # shellcheck source-path=SCRIPTDIR
+    source "$(dirname "${BASH_SOURCE[0]}")/util.sh"
+}
+
+test_is_real_run() {
+    unset BREAK_GLASS_IN_CASE_OF_EMERGENCY
+    local BUILDKITE_SOURCE
+
+    BUILDKITE_SOURCE=webhook
+    assertTrue "webhook-initiated runs are considered \"real\"" is_real_run
+
+    BUILDKITE_SOURCE=api
+    assertTrue "api-initiated runs are considered \"real\"" is_real_run
+
+    BUILDKITE_SOURCE=trigger_job
+    assertTrue "trigger-initiated runs are considered \"real\"" is_real_run
+
+    BUILDKITE_SOURCE=schedule
+    assertTrue "scheduled runs are considered \"real\"" is_real_run
+
+    BUILDKITE_SOURCE=ui
+    assertFalse "UI-initiated runs are *not* considered \"real\"" is_real_run
+
+    BUILDKITE_SOURCE=not_a_valid_buildkite_source
+    assertFalse "A run with an unrecognized BUILDKITE_SOURCE is never considered \"real\"" is_real_run
+}
+
+test_is_real_run_with_override() {
+    local BREAK_GLASS_IN_CASE_OF_EMERGENCY=1
+    local BUILDKITE_SOURCE
+
+    BUILDKITE_SOURCE=webhook
+    assertTrue "webhook-initiated runs are considered \"real\", regardless of override" is_real_run
+
+    BUILDKITE_SOURCE=api
+    assertTrue "api-initiated runs are considered \"real\", regardless of override" is_real_run
+
+    BUILDKITE_SOURCE=trigger_job
+    assertTrue "trigger-initiated runs are considered \"real\", regardless of override" is_real_run
+
+    BUILDKITE_SOURCE=schedule
+    assertTrue "scheduled runs are considered \"real\", regardless of override" is_real_run
+
+    BUILDKITE_SOURCE=ui
+    assertTrue "UI-initiated runs are *only* considered \"real\" in the presence of an override" is_real_run
+
+    BUILDKITE_SOURCE=not_a_valid_buildkite_source
+    assertFalse "A run with an unrecognized BUILDKITE_SOURCE is never considered \"real\"" is_real_run
+}

--- a/.buildkite/shared/pants
+++ b/.buildkite/shared/pants
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# =============================== NOTE ===============================
+# This ./pants bootstrap script comes from the pantsbuild/setup
+# project. It is intended to be checked into your code repository so
+# that other developers have the same setup.
+#
+# Learn more here: https://www.pantsbuild.org/docs/installation
+# ====================================================================
+
+set -eou pipefail
+
+# NOTE: To use an unreleased version of Pants from the pantsbuild/pants master branch,
+#  locate the master branch SHA, set PANTS_SHA=<SHA> in the environment, and run this script as usual.
+#
+# E.g., PANTS_SHA=725fdaf504237190f6787dda3d72c39010a4c574 ./pants --version
+
+PYTHON_BIN_NAME="${PYTHON:-unspecified}"
+
+# Set this to specify a non-standard location for this script to read the Pants version from.
+# NB: This will *not* cause Pants itself to use this location as a config file.
+#     You can use PANTS_CONFIG_FILES or --pants-config-files to do so.
+PANTS_TOML=${PANTS_TOML:-pants.toml}
+
+PANTS_BIN_NAME="${PANTS_BIN_NAME:-$0}"
+
+PANTS_SETUP_CACHE="${PANTS_SETUP_CACHE:-${XDG_CACHE_HOME:-$HOME/.cache}/pants/setup}"
+# If given a relative path, we fix it to be absolute.
+if [[ "$PANTS_SETUP_CACHE" != /* ]]; then
+  PANTS_SETUP_CACHE="${PWD}/${PANTS_SETUP_CACHE}"
+fi
+
+PANTS_BOOTSTRAP="${PANTS_SETUP_CACHE}/bootstrap-$(uname -s)-$(uname -m)"
+
+VENV_VERSION=${VENV_VERSION:-16.4.3}
+
+VENV_PACKAGE=virtualenv-${VENV_VERSION}
+VENV_TARBALL=${VENV_PACKAGE}.tar.gz
+
+COLOR_RED="\x1b[31m"
+COLOR_GREEN="\x1b[32m"
+COLOR_RESET="\x1b[0m"
+
+function log() {
+  echo -e "$@" 1>&2
+}
+
+function die() {
+  (($# > 0)) && log "${COLOR_RED}$*${COLOR_RESET}"
+  exit 1
+}
+
+function green() {
+  (($# > 0)) && log "${COLOR_GREEN}$*${COLOR_RESET}"
+}
+
+function tempdir {
+  mktemp -d "$1"/pants.XXXXXX
+}
+
+function get_exe_path_or_die {
+  local exe="$1"
+  if ! command -v "${exe}"; then
+    die "Could not find ${exe}. Please ensure ${exe} is on your PATH."
+  fi
+}
+
+function get_pants_config_value {
+  local config_key="$1"
+  local optional_space="[[:space:]]*"
+  local prefix="^${config_key}${optional_space}=${optional_space}"
+  local raw_value
+  raw_value="$(sed -ne "/${prefix}/ s#${prefix}##p" "${PANTS_TOML}")"
+  echo "${raw_value}"  | tr -d \"\' && return 0
+  return 0
+}
+
+function get_python_major_minor_version {
+  local python_exe="$1"
+  "$python_exe" <<EOF
+import sys
+major_minor_version = ''.join(str(version_num) for version_num in sys.version_info[0:2])
+print(major_minor_version)
+EOF
+}
+
+# The high-level flow:
+#
+# 1.) Resolve the Pants version from config so that we know what interpreters we can use, what to name the venv,
+#     and what to install via pip.
+# 2.) Resolve the Python interpreter, first reading from the env var $PYTHON, then using a default based on the Pants
+#     version.
+# 3.) Check if the venv already exists via a naming convention, and create the venv if not found.
+# 4.) Execute Pants with the resolved Python interpreter and venv.
+#
+# After that, Pants itself will handle making sure any requested plugins
+# are installed and up to date.
+
+function determine_pants_version {
+  if [ -n "${PANTS_SHA:-}" ]; then
+    # get_version_for_sha will echo the version, thus "returning" it from this function.
+    get_version_for_sha "$PANTS_SHA"
+    return
+  fi
+
+  pants_version="$(get_pants_config_value 'pants_version')"
+  if [[ -z "${pants_version}" ]]; then
+    die "Please explicitly specify the \`pants_version\` in your \`pants.toml\` under the
+\`[GLOBAL]\` scope. See https://pypi.org/project/pantsbuild.pants/#history for all released
+versions and https://www.pantsbuild.org/docs/installation for more instructions."
+  fi
+  pants_major_version="$(echo "${pants_version}" | cut -d '.' -f1)"
+  pants_minor_version="$(echo "${pants_version}" | cut -d '.' -f2)"
+  # 1.26 is the first version to support `pants.toml`, so we fail eagerly if using an outdated version.
+  if [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -le 25 ]]; then
+    die "This version of the \`./pants\` script does not work with Pants <= 1.25.0 (and it also requires using \`pants.toml\`,
+rather than \`pants.ini\`). Instead, either upgrade your \`pants_version\` or use the version of the \`./pants\` script
+at https://raw.githubusercontent.com/Eric-Arellano/setup/0d445edef57cb89fd830db70810e38f050b0a268/pants."
+  fi
+  echo "${pants_version}"
+}
+
+function set_supported_python_versions {
+  local pants_version="$1"
+  local pants_major_version
+  local pants_minor_version
+  pants_major_version="$(echo "${pants_version}" | cut -d '.' -f1)"
+  pants_minor_version="$(echo "${pants_version}" | cut -d '.' -f2)"
+  if [[ "${pants_major_version}" -eq 1 ]]; then
+    supported_python_versions_decimal=('3.6' '3.7' '3.8')
+    supported_python_versions_int=('36' '37' '38')
+    supported_message='3.6, 3.7, or 3.8'
+  elif [[ "${pants_major_version}" -eq 2 && "${pants_minor_version}" -eq 0 ]]; then
+    supported_python_versions_decimal=('3.6' '3.7' '3.8')
+    supported_python_versions_int=('36' '37' '38')
+    supported_message='3.6, 3.7, or 3.8'
+  elif [[ "${pants_major_version}" -eq 2 && "${pants_minor_version}" -eq 1 ]]; then
+    supported_python_versions_decimal=('3.7' '3.8' '3.6')
+    supported_python_versions_int=('37' '38' '36')
+    supported_message='3.7, 3.8, or 3.6 (deprecated)'
+  else
+    supported_python_versions_decimal=('3.7' '3.8')
+    supported_python_versions_int=('37' '38')
+    supported_message='3.7 or 3.8'
+  fi
+}
+
+function determine_default_python_exe {
+  for version in "${supported_python_versions_decimal[@]}"; do
+    local interpreter_path
+    interpreter_path="$(command -v "python${version}")"
+    if [[ -z "${interpreter_path}" ]]; then
+      continue
+    fi
+    # Check if the Python version is installed via Pyenv but not activated.
+    if [[ "$("${interpreter_path}" --version 2>&1 > /dev/null)" == "pyenv: python${version}"* ]]; then
+      continue
+    fi
+    echo "${interpreter_path}" && return 0
+  done
+}
+
+function determine_python_exe {
+  local pants_version="$1"
+  set_supported_python_versions "${pants_version}"
+  local requirement_str="For \`pants_version = \"${pants_version}\"\`, Pants requires Python ${supported_message} to run."
+
+  local python_bin_name
+  if [[ "${PYTHON_BIN_NAME}" != 'unspecified' ]]; then
+    python_bin_name="${PYTHON_BIN_NAME}"
+  else
+    python_bin_name="$(determine_default_python_exe)"
+    if [[ -z "${python_bin_name}" ]]; then
+      die "No valid Python interpreter found. ${requirement_str} Please check that a valid interpreter is installed and on your \$PATH."
+    fi
+  fi
+  local python_exe
+  python_exe="$(get_exe_path_or_die "${python_bin_name}")"
+  local major_minor_version
+  major_minor_version="$(get_python_major_minor_version "${python_exe}")"
+  for valid_version in "${supported_python_versions_int[@]}"; do
+    if [[ "${major_minor_version}" == "${valid_version}" ]]; then
+      echo "${python_exe}" && return 0
+    fi
+  done
+  die "Invalid Python interpreter version for ${python_exe}. ${requirement_str}"
+}
+
+# TODO(John Sirois): GC race loser tmp dirs leftover from bootstrap_XXX
+# functions.  Any tmp dir w/o a symlink pointing to it can go.
+
+function bootstrap_venv {
+  if [[ ! -d "${PANTS_BOOTSTRAP}/${VENV_PACKAGE}" ]]; then
+    (
+      mkdir -p "${PANTS_BOOTSTRAP}"
+      local staging_dir
+      staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
+      cd "${staging_dir}"
+      curl -LO "https://pypi.io/packages/source/v/virtualenv/${VENV_TARBALL}"
+      tar -xzf "${VENV_TARBALL}"
+      ln -s "${staging_dir}/${VENV_PACKAGE}" "${staging_dir}/latest"
+      mv "${staging_dir}/latest" "${PANTS_BOOTSTRAP}/${VENV_PACKAGE}"
+    ) 1>&2
+  fi
+  echo "${PANTS_BOOTSTRAP}/${VENV_PACKAGE}"
+}
+
+function find_links_url {
+  local pants_version="$1"
+  local pants_sha="$2"
+  echo -n "https://binaries.pantsbuild.org/wheels/pantsbuild.pants/${pants_sha}/${pants_version/+/%2B}/index.html"
+}
+
+function get_version_for_sha {
+  local sha="$1"
+
+  # Retrieve the Pants version associated with this commit.
+  local pants_version
+  pants_version="$(curl --fail -sL "https://raw.githubusercontent.com/pantsbuild/pants/${sha}/src/python/pants/VERSION")"
+
+  # Construct the version as the release version from src/python/pants/VERSION, plus the string `+gitXXXXXXXX`,
+  # where the XXXXXXXX is the first 8 characters of the SHA.
+  echo "${pants_version}+git${sha:0:8}"
+}
+
+function bootstrap_pants {
+  local pants_version="$1"
+  local python="$2"
+  local pants_sha="${3:-}"
+
+  local pants_requirement="pantsbuild.pants==${pants_version}"
+  local maybe_find_links
+  if [[ -z "${pants_sha}" ]]; then
+    maybe_find_links=""
+  else
+    maybe_find_links="--find-links=$(find_links_url "${pants_version}" "${pants_sha}")"
+   fi
+  local python_major_minor_version
+  python_major_minor_version="$(get_python_major_minor_version "${python}")"
+  local target_folder_name
+  target_folder_name="${pants_version}_py${python_major_minor_version}"
+
+  if [[ ! -d "${PANTS_BOOTSTRAP}/${target_folder_name}" ]]; then
+    (
+      local venv_path
+      venv_path="$(bootstrap_venv)"
+      local staging_dir
+      staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
+      # shellcheck disable=SC2086
+      "${python}" "${venv_path}/virtualenv.py" --no-download "${staging_dir}/install" && \
+      "${staging_dir}/install/bin/pip" install -U pip && \
+      "${staging_dir}/install/bin/pip" install ${maybe_find_links} --progress-bar off "${pants_requirement}" && \
+      ln -s "${staging_dir}/install" "${staging_dir}/${target_folder_name}" && \
+      mv "${staging_dir}/${target_folder_name}" "${PANTS_BOOTSTRAP}/${target_folder_name}" && \
+      green "New virtual environment successfully created at ${PANTS_BOOTSTRAP}/${target_folder_name}."
+    ) 1>&2
+  fi
+  echo "${PANTS_BOOTSTRAP}/${target_folder_name}"
+}
+
+# Ensure we operate from the context of the ./pants buildroot.
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+pants_version="$(determine_pants_version)"
+python="$(determine_python_exe "${pants_version}")"
+pants_dir="$(bootstrap_pants "${pants_version}" "${python}" "${PANTS_SHA:-}")"
+pants_python="${pants_dir}/bin/python"
+pants_binary="${pants_dir}/bin/pants"
+pants_extra_args=""
+if [[ -n "${PANTS_SHA:-}" ]]; then
+  pants_extra_args="${pants_extra_args} --python-repos-repos=$(find_links_url "$pants_version" "$PANTS_SHA")"
+fi
+
+# shellcheck disable=SC2086
+exec "${pants_python}" "${pants_binary}" ${pants_extra_args} \
+  --pants-bin-name="${PANTS_BIN_NAME}" --pants-version=${pants_version} "$@"

--- a/.buildkite/shared/pants.ci.toml
+++ b/.buildkite/shared/pants.ci.toml
@@ -1,0 +1,28 @@
+# Overrides to be used only in CI environments.
+#
+# Enable using:
+#
+#     export PANTS_CONFIG_FILES="['pants.toml','pants.ci.toml']"
+#
+# This will overlay any values from this file onto those from the
+# regular `pants.toml` file.
+#
+# (It also appears that specifying just `pants.ci.toml` will also
+# work, taking `pants.toml` to be the always-present base by
+# convention, but being explicit never hurt.)
+[GLOBAL]
+dynamic_ui = false
+colors = true
+
+# Since multiple jobs could run on the same Buildkite worker node, we
+# need to make sure the cache directories are isolated.
+local_store_dir = ".cache/pants/lmdb_store"
+named_caches_dir = ".cache/pants/named_caches"
+
+pants_ignore = [
+  ".cache/pants/named_caches",
+  ".cache/pants/lmdb_store",
+]
+
+[auth]
+from_env_var = "TOOLCHAIN_AUTH_TOKEN"

--- a/.buildkite/shared/pants.toml
+++ b/.buildkite/shared/pants.toml
@@ -1,0 +1,57 @@
+[GLOBAL]
+pants_version = "2.7.1"
+backend_packages = [
+    "pants.backend.shell",
+    "pants.backend.shell.lint.shellcheck",
+    "pants.backend.shell.lint.shfmt"
+]
+
+pants_ignore = [
+    "!.buildkite/"
+]
+
+plugins = [
+  "toolchain.pants.plugin==0.14.0"
+]
+
+remote_cache_read = true
+remote_cache_write = true
+remote_store_address = "grpcs://cache.toolchain.com:443"
+remote_auth_plugin = "toolchain.pants.auth.plugin:toolchain_auth_plugin"
+
+[toolchain-setup]
+repo = "buildkite-common"
+
+[buildsense]
+enable = true
+
+# See https://www.pantsbuild.org/docs/anonymous-telemetry
+[anonymous-telemetry]
+enabled = true
+# Randomly generated with `uuidgen --random`
+repo_id = "a848c0d7-1ac6-4098-92f8-c33db5cb4fc0"
+
+# [source]
+# root_patterns = [
+#     "/3rdparty",
+#     "/pulumi"
+# ]
+
+[shfmt]
+# Indent with 4 spaces
+# Indent switch cases
+# Redirect operators are followed by a space
+args = ["-i 4", "-ci", "-sr"]
+
+[test]
+output = "all"
+
+[shellcheck]
+# Currently, Pants only knows about v0.7.1, but v0.7.2 has some nice
+# relative sourcing features we'd like to take advantage of (namely,
+# `script-path=SOURCEDIR`). Once Pants knows about v0.7.2 natively, we
+# can remove these configuration values.
+version = "v0.7.2"
+known_versions = [
+  "v0.7.2|linux_x86_64|70423609f27b504d6c0c47e340f33652aea975e45f312324f2dbf91c95a3b188|1382204"
+]

--- a/.buildkite/shared/scripts/BUILD
+++ b/.buildkite/shared/scripts/BUILD
@@ -1,0 +1,1 @@
+shell_library()

--- a/.buildkite/shared/scripts/diff.sh
+++ b/.buildkite/shared/scripts/diff.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# A diffing script for use with the chronotc/monorepo-diff Buildkite
+# plugin, and aware of Grapl release pipeline conventions for verify
+# and merge pipelines.
+#
+# In particular, this will modify the diff command appropriately for
+# whether it is running in the context of a verify pipeline, or from
+# the steps of a verify pipeline being run within a merge pipeline.
+#
+# The script will output the names of files changed. DO NOT echo
+# anything else to standard output (e.g., logging statements), or it
+# will be considered as a file that changed.
+
+set -euo pipefail
+
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/record.sh"
+
+pipeline="$(pipeline_from_env)"
+readonly pipeline
+
+case "${pipeline}" in
+    merge)
+        # If the last run of the merge pipeline failed, we still want
+        # to perform the expensive operations we're using this script
+        # to be selective about.
+        #
+        # For instance, the failing run may have been building Packer
+        # AMI images, but failed due to an unrelated issue in the
+        # build scripts, or something totally unrelated to the Packer
+        # source files. The fix would then not touch those source
+        # files, and we would never rebuild the image.
+        git diff --name-only "$(tag_for_pipeline "${pipeline}")"
+        ;;
+    verify)
+        # We're on a PR branch, so what changed on this branch
+        # relative to main?
+        #
+        # > For example, origin.. is a shorthand for origin..HEAD and asks
+        #   "What did I do since I forked from the origin branch?"
+        #
+        #   - from `man 7 gitrevisions`, "SPECIFYING RANGES"
+        git diff --name-only main..
+        ;;
+    *)
+        # We don't have any other pipelines at the moment, but we'd
+        # like to fail once we do, to ensure we fix this script as
+        # appropriate.
+        exit 42
+        ;;
+esac

--- a/.buildkite/shared/steps/BUILD
+++ b/.buildkite/shared/steps/BUILD
@@ -1,0 +1,1 @@
+shell_library()

--- a/.buildkite/shared/steps/record_successful_pipeline_run.sh
+++ b/.buildkite/shared/steps/record_successful_pipeline_run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# At the end of a successful run of the pipeline, we'll want to
+# record the git SHA of the code we were running.
+#
+# This is to ensure that we can make the appropriate decision whether
+# or not to rebuild artifacts following a *failure* of this pipeline
+# for whatever reason; see the `diff.sh` script for additional
+# details.
+
+set -euo pipefail
+
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/record.sh"
+
+tag_last_success "$(pipeline_from_env)"

--- a/Makefile
+++ b/Makefile
@@ -64,3 +64,9 @@ image-push:
 
 .PHONY: all
 all: format lint test image
+
+########################################################################
+
+.PHONY: update-buildkite-shared
+update-buildkite-shared: ## Pull in changes from grapl-security/buildkite-common
+	git subtree pull --prefix .buildkite/shared git@github.com:grapl-security/buildkite-common.git main --squash

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -17,27 +17,3 @@ target "cloudsmith-cli" {
     "docker.cloudsmith.io/grapl/raw/cloudsmith-cli:${CLOUDSMITH_CLI_VERSION}"
   ]
 }
-
-########################################################################
-
-group "testing" {
-  targets = ["cloudsmith-buildkite-plugin-verify-test"]
-}
-
-variable "BUILDKITE_BUILD_ID" {
-  default = "not-running-in-buildkite"
-}
-
-# If you change any values in here, make sure to make the
-# corresponding changes, if any, to .buildkite/plugin.verify.yml and
-# .buildkite/scripts/verify_promotion.sh
-target "cloudsmith-buildkite-plugin-verify-test" {
-  context    = "."
-  dockerfile = "Dockerfile.testing"
-  args = {
-    "BUILDKITE_BUILD_ID" = "${BUILDKITE_BUILD_ID}"
-  }
-  tags = [
-    "docker.cloudsmith.io/grapl/testing-stage1/cloudsmith-buildkite-plugin-verify-test:${BUILDKITE_BUILD_ID}"
-  ]
-}

--- a/docker-bake.testing.hcl
+++ b/docker-bake.testing.hcl
@@ -1,0 +1,36 @@
+# If you change any values in here, make sure to make the
+# corresponding changes, if any, to .buildkite/plugin.verify.yml,
+# .buildkite/plugin.merge.build-container.yml and
+# .buildkite/scripts/verify_promotion.sh
+
+variable "BUILDKITE_BUILD_ID" {
+  # Containers will use the Build ID as a unique tag
+  default = "not-running-in-buildkite"
+}
+
+# Both images we're going to build are basically the same; they just
+# have different tags. As such, we can define a base image for them to
+# inherit. You should not build this target by itself.
+target "base" {
+  context    = "."
+  dockerfile = "Dockerfile.testing"
+  args = {
+    "BUILDKITE_BUILD_ID" = "${BUILDKITE_BUILD_ID}"
+  }
+}
+
+# Use this image in the verify pipeline for testing.
+target "verify-image" {
+  inherits = ["base"]
+  tags = [
+    "docker.cloudsmith.io/grapl/testing-stage1/cloudsmith-buildkite-plugin-verify-test:${BUILDKITE_BUILD_ID}"
+  ]
+}
+
+# Use this image in the merge pipeline for testing.
+target "merge-image" {
+  inherits = ["base"]
+  tags = [
+    "docker.cloudsmith.io/grapl/testing-stage1/cloudsmith-buildkite-plugin-merge-test:${BUILDKITE_BUILD_ID}"
+  ]
+}


### PR DESCRIPTION
To ensure that we only build a Cloudsmith CLI container when
necessary, we pull out any testing container declarations in
`docker-bake.hcl` (this lets our diffing logic be totally matched up
with reality; if anything changes in `docker-bake.hcl` or
`Dockerfile`, we've got a new container.

The merge pipeline itself has the logic for building the container, if
necessary, and then testing the plugin using that new container. If
all goes well, we'll promote the container to our `releases`
repository (using the current official release of the plugin).

Signed-off-by: Christopher Maier <chris@graplsecurity.com>