### PR TITLE
Use Pants for hadolint

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -13,9 +13,14 @@ steps:
           secrets:
             - cloudsmith-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN
 
-  - label: ":lint-roller::docker: Lint Dockerfile"
+  - label: ":lint-roller::docker: Lint Dockerfiles"
     command:
       - make lint-docker
+    plugins:
+      - grapl-security/vault-login#v0.1.0
+      - grapl-security/vault-env#v0.1.0:
+          secrets:
+            - cloudsmith-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN
 
   - label: ":lint-roller: Lint HCL"
     command:

--- a/.buildkite/scripts/BUILD
+++ b/.buildkite/scripts/BUILD
@@ -1,1 +1,1 @@
-shell_library()
+shell_sources()

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,9 @@
+docker_image(
+    name="cloudsmith-cli",
+    source="Dockerfile",
+)
+
+docker_image(
+    name="testing-image",
+    source="Dockerfile.testing",
+)

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ lint-hcl:
 
 .PHONY: lint-bash
 lint-bash:
-	./pants filter --target-type=shell_library,shunit2_tests :: | xargs ./pants lint
+	./pants filter --target-type=shell_sources,shunit2_tests :: | xargs ./pants lint
 
 .PHONY: lint-plugin
 lint-plugin:

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ lint: lint-docker lint-hcl lint-bash lint-plugin
 
 .PHONY: lint-docker
 lint-docker:
-	${RUN_CHECK} hadolint
+	./pants filter --target-type=docker_image :: | xargs ./pants lint
 
 .PHONY: lint-hcl
 lint-hcl:

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ lint-hcl:
 
 .PHONY: lint-bash
 lint-bash:
-	./pants lint ::
+	./pants filter --target-type=shell_library,shunit2_tests :: | xargs ./pants lint
 
 .PHONY: lint-plugin
 lint-plugin:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,13 +31,6 @@ services:
     volumes:
       - *read-only-workdir
 
-  hadolint:
-    image: hadolint/hadolint:2.6.0-debian
-    command: [ "hadolint", "Dockerfile", "Dockerfile.testing" ]
-    working_dir: /workdir
-    volumes:
-      - *read-only-workdir
-
   plugin-linter:
     image: buildkite/plugin-linter:latest # the only available tag
     command: ["--id", "grapl-security/cloudsmith"]

--- a/hooks/BUILD
+++ b/hooks/BUILD
@@ -1,3 +1,1 @@
-shell_library(
-    sources=["command"]
-)
+shell_sources(sources=["command"])

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -1,7 +1,7 @@
-shell_library()
+shell_sources()
 
 shunit2_tests(
     name="tests",
     # Currently using relative imports for tests, which aren't visible to Pants
-    dependencies=[":lib"]
+    dependencies=[":lib"],
 )

--- a/pants.toml
+++ b/pants.toml
@@ -1,9 +1,11 @@
 [GLOBAL]
-pants_version = "2.7.1"
+pants_version = "2.8.0rc5"
 backend_packages = [
     "pants.backend.shell",
     "pants.backend.shell.lint.shellcheck",
-    "pants.backend.shell.lint.shfmt"
+    "pants.backend.shell.lint.shfmt",
+    "pants.backend.experimental.docker",
+    "pants.backend.experimental.docker.lint.hadolint"
 ]
 
 pants_ignore = [


### PR DESCRIPTION
This is kicking the tires on the new Pants Docker capabilities, just
using it for linting right now.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>