### PR TITLE
Explicitly anchor name and version in package queries

### DIFF
--- a/lib/ops.sh
+++ b/lib/ops.sh
@@ -4,14 +4,19 @@
 source "$(dirname "${BASH_SOURCE[0]}")/log.sh"
 
 # Generate a series of Cloudsmith query strings to use in `cloudsmith
-# package list` call
+# package list` call.
+#
+# Note that we wrap both the name and the version in anchors (`^...$`)
+# to force them to match exactly. Otherwise, you can end up with
+# multiple results if you have similarly-named packages with the same
+# version (e.g. "foo 1.2.3" and "foobar 1.2.3").
 packages_to_queries() {
     local -r _packages="${1}"
 
     jq --raw-output --exit-status '
         to_entries
         | .[]
-        | "name:" + .key + " " + "version:" + .value' \
+        | "name:^" + .key + "$ " + "version:^" + .value + "$"' \
         <<< "${_packages}" ||
         raise_error "Problem converting package specifications to Cloudsmith query strings:\n${_packages}"
 }

--- a/lib/ops_test.sh
+++ b/lib/ops_test.sh
@@ -183,8 +183,8 @@ EOF
 
     expected=$(
         cat << EOF
-name:foo version:1.2.3
-name:bar version:2.3.4
+name:^foo$ version:^1.2.3$
+name:^bar$ version:^2.3.4$
 EOF
     )
     output="$(packages_to_queries "${packages}")"
@@ -243,8 +243,8 @@ test_packages_to_queries_works_with_valid_json() {
 
     expected=$(
         cat << EOF
-name:foo version:1.2.3
-name:barf version:4.5.6
+name:^foo$ version:^1.2.3$
+name:^barf$ version:^4.5.6$
 EOF
     )
     actual="$(packages_to_queries '{"foo": "1.2.3", "barf": "4.5.6"}')"

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -40,14 +40,14 @@ EOF
            )
 
     stub docker \
-         "${CLOUDSMITH} list packages grapl/raw --query=\"name:foo version:1.2.3\" --output-format=json : echo '{\"data\": [{\"slug_perm\": \"fooXXX\"}]}'" \
+         "${CLOUDSMITH} list packages grapl/raw --query=\"name:^foo$ version:^1.2.3$\" --output-format=json : echo '{\"data\": [{\"slug_perm\": \"fooXXX\"}]}'" \
          "${CLOUDSMITH} move --yes grapl/raw/fooXXX releases : echo 'Moved foo'" \
 
     run "${PWD}/hooks/command"
     assert_success
 
     assert_output --partial "Promoting packages from grapl/raw to grapl/releases via move"
-    assert_output --partial "Processing query 'name:foo version:1.2.3'"
+    assert_output --partial "Processing query 'name:^foo$ version:^1.2.3$'"
     assert_output --partial "Moved foo"
 
     unstub docker
@@ -76,20 +76,20 @@ EOF
            )
 
     stub docker \
-         "${CLOUDSMITH} list packages grapl/raw --query=\"name:foo version:1.2.3\" --output-format=json : echo '{\"data\": [{\"slug_perm\": \"fooXXX\"}]}'" \
+         "${CLOUDSMITH} list packages grapl/raw --query=\"name:^foo$ version:^1.2.3$\" --output-format=json : echo '{\"data\": [{\"slug_perm\": \"fooXXX\"}]}'" \
          "${CLOUDSMITH} move --yes grapl/raw/fooXXX releases : echo 'Moved foo'" \
-         "${CLOUDSMITH} list packages grapl/raw --query=\"name:bar version:2.3.4\" --output-format=json : echo '{\"data\": [{\"slug_perm\": \"barXXX\"}]}'" \
+         "${CLOUDSMITH} list packages grapl/raw --query=\"name:^bar$ version:^2.3.4$\" --output-format=json : echo '{\"data\": [{\"slug_perm\": \"barXXX\"}]}'" \
          "${CLOUDSMITH} move --yes grapl/raw/barXXX releases : echo 'Moved bar'" \
-         "${CLOUDSMITH} list packages grapl/raw --query=\"name:baz version:3.4.5\" --output-format=json : echo '{\"data\": [{\"slug_perm\": \"bazXXX\"}]}'" \
+         "${CLOUDSMITH} list packages grapl/raw --query=\"name:^baz$ version:^3.4.5$\" --output-format=json : echo '{\"data\": [{\"slug_perm\": \"bazXXX\"}]}'" \
          "${CLOUDSMITH} move --yes grapl/raw/bazXXX releases : echo 'Moved baz'"
 
     run "${PWD}/hooks/command"
     assert_success
 
     assert_output --partial "Promoting packages from grapl/raw to grapl/releases via move"
-    assert_output --partial "Processing query 'name:foo version:1.2.3'"
-    assert_output --partial "Processing query 'name:bar version:2.3.4'"
-    assert_output --partial "Processing query 'name:baz version:3.4.5'"
+    assert_output --partial "Processing query 'name:^foo$ version:^1.2.3$'"
+    assert_output --partial "Processing query 'name:^bar$ version:^2.3.4$'"
+    assert_output --partial "Processing query 'name:^baz$ version:^3.4.5$'"
     assert_output --partial "Moved foo"
     assert_output --partial "Moved bar"
     assert_output --partial "Moved baz"
@@ -124,20 +124,20 @@ EOF
 EOF
 
     stub docker \
-         "${CLOUDSMITH} list packages grapl/raw --query=\"name:file-foo version:1.2.3\" --output-format=json : echo '{\"data\": [{\"slug_perm\": \"fooXXX\"}]}'" \
+         "${CLOUDSMITH} list packages grapl/raw --query=\"name:^file-foo$ version:^1.2.3$\" --output-format=json : echo '{\"data\": [{\"slug_perm\": \"fooXXX\"}]}'" \
          "${CLOUDSMITH} move --yes grapl/raw/fooXXX releases : echo 'Moved foo'" \
-         "${CLOUDSMITH} list packages grapl/raw --query=\"name:file-bar version:2.3.4\" --output-format=json : echo '{\"data\": [{\"slug_perm\": \"barXXX\"}]}'" \
+         "${CLOUDSMITH} list packages grapl/raw --query=\"name:^file-bar$ version:^2.3.4$\" --output-format=json : echo '{\"data\": [{\"slug_perm\": \"barXXX\"}]}'" \
          "${CLOUDSMITH} move --yes grapl/raw/barXXX releases : echo 'Moved bar'" \
-         "${CLOUDSMITH} list packages grapl/raw --query=\"name:file-baz version:3.4.5\" --output-format=json : echo '{\"data\": [{\"slug_perm\": \"bazXXX\"}]}'" \
+         "${CLOUDSMITH} list packages grapl/raw --query=\"name:^file-baz$ version:^3.4.5$\" --output-format=json : echo '{\"data\": [{\"slug_perm\": \"bazXXX\"}]}'" \
          "${CLOUDSMITH} move --yes grapl/raw/bazXXX releases : echo 'Moved baz'"
 
     run "${PWD}/hooks/command"
     assert_success
 
     assert_output --partial "Promoting packages from grapl/raw to grapl/releases via move"
-    assert_output --partial "Processing query 'name:file-foo version:1.2.3'"
-    assert_output --partial "Processing query 'name:file-bar version:2.3.4'"
-    assert_output --partial "Processing query 'name:file-baz version:3.4.5'"
+    assert_output --partial "Processing query 'name:^file-foo$ version:^1.2.3$'"
+    assert_output --partial "Processing query 'name:^file-bar$ version:^2.3.4$'"
+    assert_output --partial "Processing query 'name:^file-baz$ version:^3.4.5$'"
     assert_output --partial "Moved foo"
     assert_output --partial "Moved bar"
     assert_output --partial "Moved baz"


### PR DESCRIPTION
Since we expect there to only be a single identified package to
promote, we need to add anchors to our search terms. Otherwise, we run
the risk of confusing a "foo" package with a "foobar" package, etc.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>