### PR TITLE
Update grapl-release Buildkite Plugin to v0.1.1

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -7,7 +7,7 @@ steps:
 
   - label: ":thinking_face: Build Cloudsmith Container?"
     plugins:
-      - grapl-security/grapl-release#v0.1.0
+      - grapl-security/grapl-release#v0.1.1
       - chronotc/monorepo-diff#v2.0.4:
           diff: grapl_diff.sh
           log_level: "debug"
@@ -25,4 +25,4 @@ steps:
     command:
       - record_successful_pipeline_run.sh
     plugins:
-      - grapl-security/grapl-release#v0.1.0
+      - grapl-security/grapl-release#v0.1.1


### PR DESCRIPTION
Update grapl-security/grapl-release Buildkite plugin version to v0.1.1

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖