### PR TITLE
Update Cloudsmith CLI to 0.32.0

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -3,7 +3,7 @@ group "default" {
 }
 
 variable "CLOUDSMITH_CLI_VERSION" {
-  default = "0.31.1"
+  default = "0.32.0"
 }
 
 target "cloudsmith-cli" {

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -12,6 +12,11 @@ target "cloudsmith-cli" {
   args = {
     "CLOUDSMITH_CLI_VERSION" = "${CLOUDSMITH_CLI_VERSION}"
   }
+  labels = {
+    "org.opencontainers.image.authors" = "https://graplsecurity.com"
+    "org.opencontainers.image.source"  = "https://github.com/grapl-security/cloudsmith-buildkite-plugin",
+    "org.opencontainers.image.vendor"  = "Grapl, Inc."
+  }
   tags = [
     "docker.cloudsmith.io/grapl/raw/cloudsmith-cli:latest",
     "docker.cloudsmith.io/grapl/raw/cloudsmith-cli:${CLOUDSMITH_CLI_VERSION}"


### PR DESCRIPTION
- Add standard labels to the Cloudsmith CLI container image
- Update to Cloudsmith CLI 0.32.0
