### PR TITLE
Update and lock Buildkite images

### DIFF
--- a/.buildkite/pipeline.merge.build-container.yml
+++ b/.buildkite/pipeline.merge.build-container.yml
@@ -12,7 +12,7 @@ steps:
       - grapl-security/vault-env#v0.1.0:
           secrets:
             - CLOUDSMITH_API_KEY
-      - docker-login#v2.0.1:
+      - docker-login#v2.1.0:
           username: grapl-cicd
           password-env: CLOUDSMITH_API_KEY
           server: docker.cloudsmith.io

--- a/.buildkite/pipeline.merge.build-container.yml
+++ b/.buildkite/pipeline.merge.build-container.yml
@@ -24,13 +24,16 @@ steps:
   # Re-run validation with the new image, just to be safe.
   # The generated pipeline will use the cloudsmith-cli container we just made.
 
-  - label: ":pipeline: Testing the 'move' promotion"
-    command:
-      - ".buildkite/pipeline.plugin-test.sh move | buildkite-agent pipeline upload"
+  - group: ":hammer_and_wrench: Integration Tests"
+    key: integration-tests
+    steps:
+      - label: ":pipeline: Testing the 'move' promotion"
+        command:
+          - ".buildkite/pipeline.plugin-test.sh move | buildkite-agent pipeline upload"
 
-  - label: ":pipeline: Testing the 'copy' promotion"
-    command:
-      - ".buildkite/pipeline.plugin-test.sh copy | buildkite-agent pipeline upload"
+      - label: ":pipeline: Testing the 'copy' promotion"
+        command:
+          - ".buildkite/pipeline.plugin-test.sh copy | buildkite-agent pipeline upload"
 
   - wait
 

--- a/.buildkite/pipeline.plugin-test.sh
+++ b/.buildkite/pipeline.plugin-test.sh
@@ -31,11 +31,11 @@ steps:
         command:
           - docker buildx bake ${pipeline}-${action}-image --file=docker-bake.testing.hcl --push
         plugins:
-          - grapl-security/vault-login#v0.1.0
+          - grapl-security/vault-login#v0.1.2
           - grapl-security/vault-env#v0.1.0:
               secrets:
                 - CLOUDSMITH_API_KEY
-          - docker-login#v2.0.1:
+          - docker-login#v2.1.0:
               username: grapl-cicd
               password-env: CLOUDSMITH_API_KEY
               server: docker.cloudsmith.io
@@ -46,7 +46,7 @@ steps:
         key: promotion-${action}-test
         depends_on: test-${action}-upload
         plugins:
-          - grapl-security/vault-login#v0.1.0
+          - grapl-security/vault-login#v0.1.2
           - grapl-security/vault-env#v0.1.0:
               secrets:
                 - CLOUDSMITH_API_KEY
@@ -82,7 +82,7 @@ cat << EOF
         command:
           - .buildkite/scripts/verify_promotion.sh "cloudsmith-buildkite-plugin-${pipeline}-${action}-test" "${action}"
         plugins:
-          - grapl-security/vault-login#v0.1.0
+          - grapl-security/vault-login#v0.1.2
           - grapl-security/vault-env#v0.1.0:
               secrets:
                 - CLOUDSMITH_API_KEY

--- a/.buildkite/pipeline.plugin-test.sh
+++ b/.buildkite/pipeline.plugin-test.sh
@@ -24,32 +24,34 @@ fi
 cat << EOF
 ---
 steps:
-  - label: ":cloudsmith::docker: Upload '${action}' container"
-    key: test-${action}-upload
-    command:
-      - docker buildx bake ${pipeline}-${action}-image --file=docker-bake.testing.hcl --push
-    plugins:
-      - grapl-security/vault-login#v0.1.0
-      - grapl-security/vault-env#v0.1.0:
-          secrets:
-            - CLOUDSMITH_API_KEY
-      - docker-login#v2.0.1:
-          username: grapl-cicd
-          password-env: CLOUDSMITH_API_KEY
-          server: docker.cloudsmith.io
-    agents:
-      queue: "docker"
+  - group: ":hammer_and_wrench: Integration Tests"
+    steps:
+      - label: ":cloudsmith::docker: Upload '${action}' container"
+        key: test-${action}-upload
+        command:
+          - docker buildx bake ${pipeline}-${action}-image --file=docker-bake.testing.hcl --push
+        plugins:
+          - grapl-security/vault-login#v0.1.0
+          - grapl-security/vault-env#v0.1.0:
+              secrets:
+                - CLOUDSMITH_API_KEY
+          - docker-login#v2.0.1:
+              username: grapl-cicd
+              password-env: CLOUDSMITH_API_KEY
+              server: docker.cloudsmith.io
+        agents:
+          queue: "docker"
 
-  - label: ":cloudsmith::buildkite: Promote via ${action}"
-    key: promotion-${action}-test
-    depends_on: test-${action}-upload
-    plugins:
-      - grapl-security/vault-login#v0.1.0
-      - grapl-security/vault-env#v0.1.0:
-          secrets:
-            - CLOUDSMITH_API_KEY
-      - grapl-security/cloudsmith#${BUILDKITE_COMMIT}:
-          promote:
+      - label: ":cloudsmith::buildkite: Promote via ${action}"
+        key: promotion-${action}-test
+        depends_on: test-${action}-upload
+        plugins:
+          - grapl-security/vault-login#v0.1.0
+          - grapl-security/vault-env#v0.1.0:
+              secrets:
+                - CLOUDSMITH_API_KEY
+          - grapl-security/cloudsmith#${BUILDKITE_COMMIT}:
+              promote:
 EOF
 
 if [ "${pipeline}" = "merge" ]; then
@@ -59,32 +61,32 @@ if [ "${pipeline}" = "merge" ]; then
     # NOTE: The spacing in this heredoc is *important* because it's
     # YAML
     cat << EOF
-            image: docker.cloudsmith.io/grapl/raw/cloudsmith-cli
-            tag: latest
+                image: docker.cloudsmith.io/grapl/raw/cloudsmith-cli
+                tag: latest
 EOF
 fi
 
 cat << EOF
-            org: grapl
-            action: ${action}
-            from: testing-stage1
-            to: testing-stage2
-            packages:
-              cloudsmith-buildkite-plugin-${pipeline}-${action}-test: ${BUILDKITE_BUILD_ID}
-    agents:
-      queue: "docker"
+                org: grapl
+                action: ${action}
+                from: testing-stage1
+                to: testing-stage2
+                packages:
+                  cloudsmith-buildkite-plugin-${pipeline}-${action}-test: ${BUILDKITE_BUILD_ID}
+        agents:
+          queue: "docker"
 
-  - label: ":cloudsmith::white_check_mark: Verify ${action}"
-    key: verify-promotion-${action}
-    depends_on: promotion-${action}-test
-    command:
-      - .buildkite/scripts/verify_promotion.sh "cloudsmith-buildkite-plugin-${pipeline}-${action}-test" "${action}"
-    plugins:
-      - grapl-security/vault-login#v0.1.0
-      - grapl-security/vault-env#v0.1.0:
-          secrets:
-            - CLOUDSMITH_API_KEY
-    agents:
-      queue: "docker"
+      - label: ":cloudsmith::white_check_mark: Verify ${action}"
+        key: verify-promotion-${action}
+        depends_on: promotion-${action}-test
+        command:
+          - .buildkite/scripts/verify_promotion.sh "cloudsmith-buildkite-plugin-${pipeline}-${action}-test" "${action}"
+        plugins:
+          - grapl-security/vault-login#v0.1.0
+          - grapl-security/vault-env#v0.1.0:
+              secrets:
+                - CLOUDSMITH_API_KEY
+        agents:
+          queue: "docker"
 
 EOF

--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -1,3 +1,4 @@
+---
 env:
   PANTS_CONFIG_FILES: "['pants.toml', 'pants.ci.toml']"
   BUILDKITE_PLUGIN_VAULT_ENV_SECRET_PREFIX: "secret/data/buildkite/env"
@@ -7,44 +8,50 @@ steps:
     command:
       - ./pants tailor --check
 
-  - label: ":lint-roller::bash: Lint Shell"
-    command:
-      - make lint-shell
-    plugins:
-      - grapl-security/vault-login#v0.1.2
-      - grapl-security/vault-env#v0.1.0:
-          secrets:
-            - cloudsmith-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN
+  - group: ":lint-roller: Lints"
+    key: lints
+    steps:
+      - label: ":bash: Lint Shell"
+        command:
+          - make lint-shell
+        plugins:
+          - grapl-security/vault-login#v0.1.2
+          - grapl-security/vault-env#v0.1.0:
+              secrets:
+                - cloudsmith-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN
 
-  - label: ":lint-roller::docker: Lint Dockerfiles"
-    command:
-      - make lint-docker
-    plugins:
-      - grapl-security/vault-login#v0.1.2
-      - grapl-security/vault-env#v0.1.0:
-          secrets:
-            - cloudsmith-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN
+      - label: ":docker: Lint Dockerfiles"
+        command:
+          - make lint-docker
+        plugins:
+          - grapl-security/vault-login#v0.1.2
+          - grapl-security/vault-env#v0.1.0:
+              secrets:
+                - cloudsmith-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN
 
-  - label: ":lint-roller: Lint HCL"
-    command:
-      - make lint-hcl
+      - label: "Lint HCL"
+        command:
+          - make lint-hcl
 
-  - label: ":lint-roller::buildkite: Lint Plugin"
-    command:
-      - make lint-plugin
+      - label: ":buildkite: Lint Plugin"
+        command:
+          - make lint-plugin
 
-  - label: ":bash: Unit Test Shell"
-    command:
-      - make test-shell
-    plugins:
-      - grapl-security/vault-login#v0.1.2
-      - grapl-security/vault-env#v0.1.0:
-          secrets:
-            - cloudsmith-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN
+  - group: "Unit Tests"
+    key: unit-tests
+    steps:
+      - label: ":bash: Unit Test Shell"
+        command:
+          - make test-shell
+        plugins:
+          - grapl-security/vault-login#v0.1.2
+          - grapl-security/vault-env#v0.1.0:
+              secrets:
+                - cloudsmith-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN
 
-  - label: ":buildkite::bash: Unit Test Plugin"
-    command:
-      - make test-plugin
+      - label: ":buildkite: Test Plugin"
+        command:
+          - make test-plugin
 
   - label: ":docker: Build Image"
     command:
@@ -54,10 +61,13 @@ steps:
 
   - wait
 
-  - label: ":pipeline: Testing the 'move' promotion"
-    command:
-      - ".buildkite/pipeline.plugin-test.sh move | buildkite-agent pipeline upload"
+  - group: ":hammer_and_wrench: Integration Tests"
+    key: integration-tests
+    steps:
+      - label: ":pipeline: Testing the 'move' promotion"
+        command:
+          - ".buildkite/pipeline.plugin-test.sh move | buildkite-agent pipeline upload"
 
-  - label: ":pipeline: Testing the 'copy' promotion"
-    command:
-      - ".buildkite/pipeline.plugin-test.sh copy | buildkite-agent pipeline upload"
+      - label: ":pipeline: Testing the 'copy' promotion"
+        command:
+          - ".buildkite/pipeline.plugin-test.sh copy | buildkite-agent pipeline upload"

--- a/Makefile
+++ b/Makefile
@@ -1,70 +1,88 @@
 COMPOSE_USER=$(shell id -u):$(shell id -g)
-
-RUN_CHECK := docker-compose run --rm --user=${COMPOSE_USER}
+DOCKER_COMPOSE_CHECK := docker-compose run --rm --user=$(COMPOSE_USER)
+PANTS_SHELL_FILTER := ./pants filter --target-type=shell_sources,shunit2_tests :: | xargs ./pants
 
 .DEFAULT_GOAL=all
 
-# Formatting
-########################################################################
+.PHONY: all
+all: format
+all: lint
+all: test
+all: image
+all: ## Run (almost!) everything
 
-.PHONY: format
-format: format-hcl format-shell
+.PHONY: help
+help: ## Print this help
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make <target>\n"} \
+		 /^[a-zA-Z0-9_-]+:.*?##/ { printf "  %-46s %s\n", $$1, $$2 } \
+		 /^##@/ { printf "\n%s\n", substr($$0, 5) } ' \
+		 $(MAKEFILE_LIST)
+	@printf '\n'
 
-.PHONY: format-hcl
-format-hcl:
-	${RUN_CHECK} hcl-formatter
-
-.PHONY: format-shell
-format-shell:
-	./pants fmt ::
-
-# Linting
+##@ Linting
 ########################################################################
 
 .PHONY: lint
-lint: lint-docker lint-hcl lint-shell lint-plugin
+lint: lint-docker
+lint: lint-hcl
+lint: lint-plugin
+lint: lint-shell
+lint: ## Perform lint checks on all files
 
 .PHONY: lint-docker
-lint-docker:
+lint-docker: ## Lint Dockerfiles
 	./pants filter --target-type=docker_image :: | xargs ./pants lint
 
 .PHONY: lint-hcl
-lint-hcl:
-	${RUN_CHECK} hcl-linter
-
-.PHONY: lint-shell
-lint-shell:
-	./pants filter --target-type=shell_sources,shunit2_tests :: | xargs ./pants lint
+lint-hcl: ## Lint HCL files
+	$(DOCKER_COMPOSE_CHECK) hcl-linter
 
 .PHONY: lint-plugin
-lint-plugin:
-	${RUN_CHECK} plugin-linter
+lint-plugin: ## Lint the Buildkite plugin metadata
+	$(DOCKER_COMPOSE_CHECK) plugin-linter
 
-# Testing
+.PHONY: lint-shell
+lint-shell: ## Lint shell scripts
+	$(PANTS_SHELL_FILTER) lint
+
+##@ Formatting
+########################################################################
+
+.PHONY: format
+format: format-hcl
+format: format-shell
+format: ## Automatically format all code
+
+.PHONY: format-hcl
+format-hcl: ## Format HCL files
+	$(DOCKER_COMPOSE_CHECK) hcl-formatter
+
+.PHONY: format-shell
+format-shell: ## Format shell scripts
+	$(PANTS_SHELL_FILTER) fmt
+
+##@ Testing
 ########################################################################
 .PHONY: test
-test: test-shell test-plugin
-
-.PHONY: test-shell
-test-shell:
-	./pants test ::
+test: test-plugin
+test: test-shell
+test: ## Run all tests
 
 .PHONY: test-plugin
-test-plugin:
-	${RUN_CHECK} plugin-tester
+test-plugin: ## Test the Buildkite plugin locally (does *not* run a Buildkite pipeline)
+	$(DOCKER_COMPOSE_CHECK) plugin-tester
 
-# Containers
+.PHONY: test-shell
+test-shell: ## Unit test shell scripts
+	$(PANTS_SHELL_FILTER) test
+
+##@ Container Images
 ########################################################################
 
 .PHONY: image
-image:
+image: ## Build the Cloudsmith container image
 	docker buildx bake
 
 .PHONY: image-push
-image-push:
+image-push: ## Build *and* push the Cloudsmith container image to a repository
 	docker buildx bake --push
-
-########################################################################
-
-.PHONY: all
-all: format lint test image

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 COMPOSE_USER=$(shell id -u):$(shell id -g)
-DOCKER_COMPOSE_CHECK := docker-compose run --rm --user=$(COMPOSE_USER)
+DOCKER_COMPOSE_CHECK := docker compose run --rm --user=$(COMPOSE_USER)
 PANTS_SHELL_FILTER := ./pants filter --target-type=shell_sources,shunit2_tests :: | xargs ./pants
 
 .DEFAULT_GOAL=all

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Cannot be used if `packages` is used.
 
 ## Building
 
-Requires `make`, `docker`, and `docker-compose`.
+Requires `make`, `docker`, and Docker Compose v2.
 
 Running `make` will run all formatting, linting, and testing.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,6 @@ services:
       - *read-only-plugin
 
   plugin-tester:
-    image: buildkite/plugin-tester:latest # the only available tag
+    image: buildkite/plugin-tester:v2.0.0
     volumes:
       - *read-only-plugin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 x-common-variables:
   read-only-workdir: &read-only-workdir
     type: bind

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - *read-only-workdir
 
   plugin-linter:
-    image: buildkite/plugin-linter:latest # the only available tag
+    image: buildkite/plugin-linter@sha256:833b1ce8326b038c748c8f04d317045205e115b1732a6842ec4a957f550fe357
     command: ["--id", "grapl-security/cloudsmith"]
     volumes:
       - *read-only-plugin

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load "$BATS_PATH/load.bash"
+load "$BATS_PLUGIN_PATH/load.bash"
 
 # Uncomment to enable stub debugging
 # export DOCKER_STUB_DEBUG=/dev/tty


### PR DESCRIPTION
Our weekly maintenance pipeline run failed, which brought this weekend's [`buildkite-plugin-tester v2.0.0 release](https://github.com/buildkite-plugins/buildkite-plugin-tester/releases/tag/v2.0.0) to our attention. It updates several bits of BATS infrastructure, but also introduces a breaking change (this is the ultimate cause of our maintenance pipeline failures).

This PR locks us to the `v2.0.0` release of the `plugin-tester` image, and addresses the breaking change.

I also noticed that our use of the `buildkite/plugin-linter` image was also pinned to `latest`, just as our `buildkite/plugin-tester` image was. There are no formal release of this image (yet :crossed_fingers:), so I've pinned it to a concrete SHA to be safe.

While making these fixes, I also took the liberty of shifting our Docker Compose usage explicitly to v2, as we have been doing across all our projects lately.

(This repository also needed some general organizational updates for the Makefile and pipeline YAML, so these were also done in this PR.)