### PR TITLE
Update `vault-login` Buildkite plugin to `v0.1.3`

### DIFF
--- a/.buildkite/pipeline.merge.build-container.yml
+++ b/.buildkite/pipeline.merge.build-container.yml
@@ -8,7 +8,7 @@ steps:
     command:
       - make image-push
     plugins:
-      - grapl-security/vault-login#v0.1.2
+      - grapl-security/vault-login#v0.1.3
       - grapl-security/vault-env#v0.1.0:
           secrets:
             - CLOUDSMITH_API_KEY
@@ -40,7 +40,7 @@ steps:
   # If everything passed, we'll go ahead and promote the new image
   - label: ":cloudsmith::buildkite: Promote new cloudsmith-cli image"
     plugins:
-      - grapl-security/vault-login#v0.1.2
+      - grapl-security/vault-login#v0.1.3
       - grapl-security/vault-env#v0.1.0:
           secrets:
             - CLOUDSMITH_API_KEY

--- a/.buildkite/pipeline.plugin-test.sh
+++ b/.buildkite/pipeline.plugin-test.sh
@@ -31,7 +31,7 @@ steps:
         command:
           - docker buildx bake ${pipeline}-${action}-image --file=docker-bake.testing.hcl --push
         plugins:
-          - grapl-security/vault-login#v0.1.2
+          - grapl-security/vault-login#v0.1.3
           - grapl-security/vault-env#v0.1.0:
               secrets:
                 - CLOUDSMITH_API_KEY
@@ -46,7 +46,7 @@ steps:
         key: promotion-${action}-test
         depends_on: test-${action}-upload
         plugins:
-          - grapl-security/vault-login#v0.1.2
+          - grapl-security/vault-login#v0.1.3
           - grapl-security/vault-env#v0.1.0:
               secrets:
                 - CLOUDSMITH_API_KEY
@@ -82,7 +82,7 @@ cat << EOF
         command:
           - .buildkite/scripts/verify_promotion.sh "cloudsmith-buildkite-plugin-${pipeline}-${action}-test" "${action}"
         plugins:
-          - grapl-security/vault-login#v0.1.2
+          - grapl-security/vault-login#v0.1.3
           - grapl-security/vault-env#v0.1.0:
               secrets:
                 - CLOUDSMITH_API_KEY

--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -15,7 +15,7 @@ steps:
         command:
           - make lint-shell
         plugins:
-          - grapl-security/vault-login#v0.1.2
+          - grapl-security/vault-login#v0.1.3
           - grapl-security/vault-env#v0.1.0:
               secrets:
                 - cloudsmith-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN
@@ -24,7 +24,7 @@ steps:
         command:
           - make lint-docker
         plugins:
-          - grapl-security/vault-login#v0.1.2
+          - grapl-security/vault-login#v0.1.3
           - grapl-security/vault-env#v0.1.0:
               secrets:
                 - cloudsmith-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN
@@ -44,7 +44,7 @@ steps:
         command:
           - make test-shell
         plugins:
-          - grapl-security/vault-login#v0.1.2
+          - grapl-security/vault-login#v0.1.3
           - grapl-security/vault-env#v0.1.0:
               secrets:
                 - cloudsmith-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN


### PR DESCRIPTION
Update grapl-security/vault-login Buildkite plugin version to v0.1.3

Picks up additional logging features, specifically https://github.com/grapl-security/vault-login-buildkite-plugin/pull/26

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖