### PR TITLE
Update `buildkite/plugin-tester` image to v3.0.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,6 @@ services:
       - *read-only-plugin
 
   plugin-tester:
-    image: buildkite/plugin-tester:v2.0.0
+    image: buildkite/plugin-tester:v3.0.0
     volumes:
       - *read-only-plugin


### PR DESCRIPTION
https://github.com/buildkite-plugins/buildkite-plugin-tester/releases/tag/v3.0.0

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
